### PR TITLE
When invoking cache eviction, quickly ignore the item which cannot be…

### DIFF
--- a/falcon_store/src/disk_cache/disk_cache.cpp
+++ b/falcon_store/src/disk_cache/disk_cache.cpp
@@ -195,6 +195,7 @@ void DiskCache::CleanupForEvict(uint64_t preAllocSize)
 
     for (auto it = cacheItems.begin(); it != cacheItems.end();) {
         if (it->refs > 0) {
+            ++it;
             continue;
         }
         uint64_t key = it->inode;
@@ -250,6 +251,7 @@ void DiskCache::Cleanup()
 
     for (auto it = cacheItems.begin(); it != cacheItems.end();) {
         if (it->refs > 0) {
+            ++it;
             continue;
         }
         uint64_t key = it->inode;


### PR DESCRIPTION
… evicted