### PR TITLE
[Bugfix] fix the PostgreSQL bug in vacuum RelationTruncate

### DIFF
--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -7,3 +7,9 @@ if git -C ../third_party/postgres/ apply --reverse --check ../../patches/postgre
 else
     git -C ../third_party/postgres/ apply ../../patches/postgres.patch
 fi
+
+if git -C ../third_party/postgres/ apply --reverse --check ../../patches/postgresql_RelationTruncate_bugfix.patch &> /dev/null; then
+    echo "postgresql_RelationTruncate_bugfix patch already applied. skipping."
+else
+    git -C ../third_party/postgres/ apply ../../patches/postgresql_RelationTruncate_bugfix.patch
+fi

--- a/patches/postgresql_RelationTruncate_bugfix.patch
+++ b/patches/postgresql_RelationTruncate_bugfix.patch
@@ -1,0 +1,22 @@
+diff --git a/src/backend/catalog/storage.c b/src/backend/catalog/storage.c
+index c06e414a38f..b814339a620 100644
+--- a/src/backend/catalog/storage.c
++++ b/src/backend/catalog/storage.c
+@@ -360,6 +360,8 @@ RelationTruncate(Relation rel, BlockNumber nblocks)
+ 	 * failure to truncate, that might spell trouble at WAL replay, into a
+ 	 * certain PANIC.
+ 	 */
++	START_CRIT_SECTION();
++
+ 	if (RelationNeedsWAL(rel))
+ 	{
+ 		/*
+@@ -396,6 +398,8 @@ RelationTruncate(Relation rel, BlockNumber nblocks)
+ 	 */
+ 	smgrtruncate(RelationGetSmgr(rel), forks, nforks, blocks);
+ 
++	END_CRIT_SECTION();
++
+ 	/* We've done all the critical work, so checkpoints are OK now. */
+ 	MyProc->delayChkptFlags &= ~DELAY_CHKPT_COMPLETE;
+ 


### PR DESCRIPTION
truncate logging and its actual execution are not wrapped into a critical section, such that auto vacuum canceling during RelationTruncate may cause standby to reference invalid pages beyond the relation size.