### PR TITLE
Fix core dump caused by InterruptHoldoffCount assertion failure during concurrent file creation

### DIFF
--- a/falcon/include/utils/rwlock.h
+++ b/falcon/include/utils/rwlock.h
@@ -29,4 +29,41 @@ void RWLockAcquire(RWLock *lock, RWLockMode mode);
 void RWLockRelease(RWLock *lock);
 void RWLockReleaseAll(bool keepInterruptHoldoffCount);
 
+/*
+ * RWLockGetHeldCount - Get current number of held RWLocks
+ *
+ * Returns the count of locks in held_rwlocks array. Used by sub-transaction
+ * callback to record the lock state at sub-transaction start.
+ */
+int RWLockGetHeldCount(void);
+
+/*
+ * RWLockReleaseSince - Release RWLocks acquired after savedCount
+ *
+ * Parameters:
+ *   savedCount - Number of locks held before the critical section (e.g., before
+ *                sub-transaction start). Only locks at indices >= savedCount
+ *                will be released.
+ *   keepInterruptHoldoffCount - If true, preserve InterruptHoldoffCount value
+ *                               across the release loop. Critical for error
+ *                               handling when errfinish() has reset the count.
+ *
+ * Context:
+ *   This function is designed for sub-transaction abort handling. When a
+ *   sub-transaction aborts due to ERROR:
+ *   1. errfinish() forcibly resets InterruptHoldoffCount to 0
+ *   2. We need to release locks acquired during the sub-transaction
+ *   3. But we must preserve parent transaction's locks
+ *   4. And we must not disturb the InterruptHoldoffCount = 0 state
+ *
+ * Implementation:
+ *   - Save InterruptHoldoffCount before the loop
+ *   - For each lock release, temporarily HOLD_INTERRUPTS() to offset the
+ *     RESUME_INTERRUPTS() inside RWLockRelease()
+ *   - After the loop, restore InterruptHoldoffCount to its saved value
+ *   - This ensures the loop's internal HOLD/RESUME pairs don't affect
+ *     external state, even if the loop exits abnormally
+ */
+void RWLockReleaseSince(int savedCount, bool keepInterruptHoldoffCount);
+
 #endif

--- a/falcon/metadb/foreign_server.c
+++ b/falcon/metadb/foreign_server.c
@@ -109,10 +109,12 @@ Datum falcon_insert_foreign_server(PG_FUNCTION_ARGS)
     bool isLocal = PG_GETARG_BOOL(4);
     char *userName = PG_GETARG_CSTRING(5);
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     Relation rel = table_open(ForeignServerRelationId(), RowExclusiveLock);
     InsertForeignServerByRel(rel, serverId, serverName, host, port, isLocal, userName);
 
     table_close(rel, RowExclusiveLock);
+    PopActiveSnapshot();
     InvalidateForeignServerShmemCache();
 
     PG_RETURN_INT16(0);
@@ -122,9 +124,11 @@ Datum falcon_delete_foreign_server(PG_FUNCTION_ARGS)
 {
     int32_t serverId = PG_GETARG_INT32(0);
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     Relation rel = table_open(ForeignServerRelationId(), RowExclusiveLock);
     DeleteForeignServerByRel(rel, serverId);
     table_close(rel, RowExclusiveLock);
+    PopActiveSnapshot();
     InvalidateForeignServerShmemCache();
 
     PG_RETURN_INT16(0);
@@ -136,9 +140,11 @@ Datum falcon_update_foreign_server(PG_FUNCTION_ARGS)
     char *host = PG_GETARG_CSTRING(1);
     int32_t port = PG_GETARG_INT32(2);
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     Relation rel = table_open(ForeignServerRelationId(), RowExclusiveLock);
     UpdateForeignServerByRel(rel, serverId, host, port);
     table_close(rel, RowExclusiveLock);
+    PopActiveSnapshot();
     InvalidateForeignServerShmemCache();
     PG_RETURN_INT16(0);
 }

--- a/falcon/metadb/meta_plain_interface.c
+++ b/falcon/metadb/meta_plain_interface.c
@@ -10,6 +10,7 @@
 #include "metadb/meta_process_info.h"
 #include "utils/builtins.h"
 #include "utils/error_log.h"
+#include "utils/snapmgr.h"
 #include "utils/timestamp.h"
 #include "utils/utils.h"
 
@@ -27,7 +28,9 @@ Datum falcon_plain_mkdir(PG_FUNCTION_ARGS)
     MetaProcessInfo info = &infoData;
     info->path = path;
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     FalconMkdirHandle(&info, 1);
+    PopActiveSnapshot();
 
     PG_RETURN_INT32(info->errorCode);
 }
@@ -40,7 +43,9 @@ Datum falcon_plain_create(PG_FUNCTION_ARGS)
     MetaProcessInfo info = &infoData;
     info->path = path;
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     FalconCreateHandle(&info, 1, false);
+    PopActiveSnapshot();
 
     PG_RETURN_INT32(info->errorCode);
 }
@@ -53,7 +58,9 @@ Datum falcon_plain_stat(PG_FUNCTION_ARGS)
     MetaProcessInfo info = &infoData;
     info->path = path;
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     FalconStatHandle(&info, 1);
+    PopActiveSnapshot();
 
     PG_RETURN_INT32(info->errorCode);
 }
@@ -66,7 +73,9 @@ Datum falcon_plain_rmdir(PG_FUNCTION_ARGS)
     MetaProcessInfo info = &infoData;
     info->path = path;
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     FalconRmdirHandle(info);
+    PopActiveSnapshot();
 
     PG_RETURN_INT32(info->errorCode);
 }
@@ -82,7 +91,9 @@ Datum falcon_plain_readdir(PG_FUNCTION_ARGS)
     info->readDirLastShardIndex = -1;
     info->readDirLastFileName = "";
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     FalconReadDirHandle(info);
+    PopActiveSnapshot();
 
     StringInfo result = makeStringInfo();
     for (int i = 0; i < info->readDirResultCount; ++i) {

--- a/falcon/metadb/shard_table.c
+++ b/falcon/metadb/shard_table.c
@@ -54,6 +54,7 @@ Datum falcon_build_shard_table(PG_FUNCTION_ARGS)
         FALCON_ELOG_ERROR(ARGUMENT_ERROR, "no worker.");
 
     int serverRound = 0;
+    PushActiveSnapshot(GetTransactionSnapshot());
     Relation rel = table_open(ShardRelationId(), RowExclusiveLock);
     CatalogIndexState indstate = CatalogOpenIndexes(rel);
     TupleDesc tupleDesc = RelationGetDescr(rel);
@@ -78,6 +79,7 @@ Datum falcon_build_shard_table(PG_FUNCTION_ARGS)
     CommandCounterIncrement();
     CatalogCloseIndexes(indstate);
     table_close(rel, RowExclusiveLock);
+    PopActiveSnapshot();
     InvalidateShardTableShmemCache();
 
     PG_RETURN_INT16(0);
@@ -98,6 +100,7 @@ Datum falcon_update_shard_table(PG_FUNCTION_ARGS)
         FALCON_ELOG_ERROR(ARGUMENT_ERROR, "range_point array must be as long as server_id array.");
     int changeCount = rangePointCount;
 
+    PushActiveSnapshot(GetTransactionSnapshot());
     Relation rel = table_open(ShardRelationId(), RowExclusiveLock);
     CatalogIndexState indstate = CatalogOpenIndexes(rel);
     TupleDesc tupleDesc = RelationGetDescr(rel);
@@ -135,6 +138,7 @@ Datum falcon_update_shard_table(PG_FUNCTION_ARGS)
 
     CatalogCloseIndexes(indstate);
     table_close(rel, RowExclusiveLock);
+    PopActiveSnapshot();
     InvalidateShardTableShmemCache();
 
     PG_RETURN_INT16(0);

--- a/falcon/transaction/transaction.c
+++ b/falcon/transaction/transaction.c
@@ -30,9 +30,29 @@
 static FalconExplicitTransactionState falconExplicitTransactionState = FALCON_EXPLICIT_TRANSACTION_NONE;
 
 static void FalconTransactionCallback(XactEvent event, void *args);
+static void FalconSubTransactionCallback(SubXactEvent event, SubTransactionId mySubid,
+                                          SubTransactionId parentSubid, void *arg);
 
 char PreparedTransactionGid[MAX_TRANSACTION_GID_LENGTH + 1];
 char RemoteTransactionGid[MAX_TRANSACTION_GID_LENGTH + 1];
+
+/*
+ * Sub-transaction RWLock state tracking
+ *
+ * We use a stack to track the number of held RWLocks at each sub-transaction
+ * level. When a sub-transaction starts, we record RWLockGetHeldCount().
+ * When it aborts, we release only locks acquired during that sub-transaction
+ * by calling RWLockReleaseSince(savedCount, true).
+ *
+ * This preserves parent transaction's locks (e.g., path locks acquired during
+ * PHASE 1 of CreateHandle) while cleaning up the sub-transaction's locks.
+ *
+ * Maximum nesting depth: 16 levels (should be sufficient for normal use cases).
+ * If exceeded, FALCON_ELOG_ERROR will be raised in FalconSubTransactionCallback.
+ */
+#define MAX_SUB_XACT_DEPTH 16
+static int subXactRWLockStack[MAX_SUB_XACT_DEPTH];
+static int subXactRWLockStackTop = 0;
 
 static void ClearRemoteTransactionGid()
 {
@@ -144,7 +164,11 @@ extern void FalconExplicitTransactionRollbackPrepared(const char *gid)
     falconExplicitTransactionState = FALCON_EXPLICIT_TRANSACTION_NONE;
 }
 
-void RegisterFalconTransactionCallback(void) { RegisterXactCallback(FalconTransactionCallback, NULL); }
+void RegisterFalconTransactionCallback(void)
+{
+    RegisterXactCallback(FalconTransactionCallback, NULL);
+    RegisterSubXactCallback(FalconSubTransactionCallback, NULL);
+}
 
 static void FalconTransactionCallback(XactEvent event, void *args)
 {
@@ -189,6 +213,134 @@ static void FalconTransactionCallback(XactEvent event, void *args)
     case XACT_EVENT_PARALLEL_COMMIT:
     case XACT_EVENT_PARALLEL_PRE_COMMIT:
     case XACT_EVENT_PARALLEL_ABORT: {
+        break;
+    }
+    }
+}
+
+/*
+ * FalconSubTransactionCallback - Handle sub-transaction events for RWLock cleanup
+ *
+ * This callback is registered via RegisterSubXactCallback() and is invoked by
+ * PostgreSQL at key sub-transaction lifecycle points.
+ *
+ * Problem being solved:
+ *   When a sub-transaction aborts due to ERROR (e.g., unique key violation in
+ *   InsertIntoInodeTable), PostgreSQL's errfinish() forcibly resets
+ *   InterruptHoldoffCount to 0. However, Falcon's held_rwlocks array is not
+ *   automatically cleaned up, causing two issues:
+ *
+ *   1. Stale lock entries remain in held_rwlocks, leading to incorrect lock
+ *      release attempts later (possibly double-free or releasing wrong locks)
+ *
+ *   2. InterruptHoldoffCount mismatch: at main transaction commit,
+ *      CommitTransaction() expects InterruptHoldoffCount > 0 but finds 0,
+ *      causing assertion failure: "InterruptHoldoffCount > 0"
+ *
+ * Solution:
+ *   Track the number of held locks at sub-transaction start, and on abort,
+ *   release only locks acquired during that sub-transaction using
+ *   RWLockReleaseSince(). This:
+ *   - Cleans up stale lock entries
+ *   - Preserves parent transaction's locks (e.g., path locks from PHASE 1)
+ *   - Maintains InterruptHoldoffCount consistency via keepInterruptHoldoffCount=true
+ *
+ * Events handled:
+ *   SUBXACT_EVENT_START_SUB:   Push current lock count onto stack
+ *   SUBXACT_EVENT_ABORT_SUB:   Pop stack and release locks since saved count
+ *   SUBXACT_EVENT_COMMIT_SUB:  Pop stack (locks become part of parent)
+ *   SUBXACT_EVENT_PRE_COMMIT_SUB: No action needed
+ */
+static void FalconSubTransactionCallback(SubXactEvent event, SubTransactionId mySubid,
+                                          SubTransactionId parentSubid, void *arg)
+{
+    switch (event) {
+    case SUBXACT_EVENT_START_SUB: {
+        /*
+         * Record the current number of held RWLocks at sub-transaction start.
+         *
+         * This snapshot represents the "baseline" - locks held by the parent
+         * transaction. Any locks acquired during this sub-transaction will
+         * have indices >= this saved count.
+         *
+         * Example:
+         *   Parent holds lock1 (num_held_rwlocks = 1)
+         *   Sub-tx starts: savedCount = 1
+         *   Sub-tx acquires lock2, lock3 (num_held_rwlocks = 3)
+         *   Sub-tx aborts: release locks at indices [1, 2] (lock2, lock3)
+         *   Result: lock1 (index 0) is preserved
+         */
+        if (subXactRWLockStackTop >= MAX_SUB_XACT_DEPTH)
+            FALCON_ELOG_ERROR_EXTENDED(PROGRAM_ERROR,
+                                       "sub-transaction nesting depth (%d) exceeds maximum (%d)",
+                                       subXactRWLockStackTop,
+                                       MAX_SUB_XACT_DEPTH);
+
+        subXactRWLockStack[subXactRWLockStackTop++] = RWLockGetHeldCount();
+        break;
+    }
+
+    case SUBXACT_EVENT_ABORT_SUB: {
+        /*
+         * Sub-transaction is aborting - release only locks acquired during
+         * this sub-transaction.
+         *
+         * Context at this point:
+         *   - An ERROR has been thrown (e.g., unique key violation)
+         *   - errfinish() has reset InterruptHoldoffCount to 0
+         *   - held_rwlocks array still contains all locks (parent + sub-tx)
+         *   - We're in the PG_CATCH block or error recovery path
+         *
+         * Critical parameter: keepInterruptHoldoffCount = true
+         *   This tells RWLockReleaseSince to preserve the current
+         *   InterruptHoldoffCount value (0) instead of letting it decrement
+         *   naturally. Without this, the count would go negative.
+         *
+         * Safety guarantee:
+         *   Only locks at indices >= savedCount are released. Parent
+         *   transaction's locks (indices < savedCount) remain untouched.
+         *   This is crucial for operations like CreateHandle which acquire
+         *   path locks in PHASE 1 (parent tx) and may abort a sub-tx in
+         *   PHASE 2 without releasing those path locks.
+         *
+         * IMPORTANT: We must read savedCount BEFORE decrementing the stack top.
+         *   If RWLockReleaseSince() throws an error, we want the stack to remain
+         *   in a consistent state so that outer error handling can retry or
+         *   handle the situation correctly. Decrementing the stack top first
+         *   would cause a lock leak if RWLockReleaseSince() fails.
+         */
+        if (subXactRWLockStackTop <= 0)
+            FALCON_ELOG_ERROR_EXTENDED(PROGRAM_ERROR,
+                                       "sub-transaction RWLock stack underflow (top = %d)",
+                                       subXactRWLockStackTop);
+
+        int savedCount = subXactRWLockStack[subXactRWLockStackTop - 1];
+        RWLockReleaseSince(savedCount, true);
+        subXactRWLockStackTop--;
+        break;
+    }
+
+    case SUBXACT_EVENT_COMMIT_SUB: {
+        /*
+         * Sub-transaction is committing successfully - locks acquired during
+         * this sub-transaction become part of the parent transaction's locks.
+         *
+         * We simply pop the stack without releasing any locks. The locks will
+         * be released when the parent transaction commits/aborts, or when a
+         * parent-level sub-transaction aborts (in which case its savedCount
+         * will be less than the current num_held_rwlocks).
+         */
+        if (subXactRWLockStackTop <= 0)
+            FALCON_ELOG_ERROR_EXTENDED(PROGRAM_ERROR,
+                                       "sub-transaction RWLock stack underflow on commit (top = %d)",
+                                       subXactRWLockStackTop);
+
+        subXactRWLockStackTop--;
+        break;
+    }
+
+    case SUBXACT_EVENT_PRE_COMMIT_SUB: {
+        /* No action needed before sub-transaction commit */
         break;
     }
     }

--- a/falcon/utils/rwlock.c
+++ b/falcon/utils/rwlock.c
@@ -181,6 +181,160 @@ void RWLockRelease(RWLock *lock)
 }
 
 /*
+ * RWLockGetHeldCount - Get current number of held RWLocks
+ *
+ * Returns the current size of the held_rwlocks array. This represents
+ * the number of RWLock acquire operations (RWLockAcquire or RWLockDeclare)
+ * that have been performed but not yet released.
+ *
+ * Used by sub-transaction callback to snapshot the lock state at the
+ * beginning of a sub-transaction, so we can restore to this state on abort.
+ */
+int RWLockGetHeldCount(void)
+{
+    return num_held_rwlocks;
+}
+
+/*
+ * RWLockReleaseSince - Release RWLocks acquired after savedCount
+ *
+ * Releases all locks at indices >= savedCount in the held_rwlocks array,
+ * effectively restoring the lock state to what it was when savedCount
+ * locks were held.
+ *
+ * The keepInterruptHoldoffCount parameter controls InterruptHoldoffCount
+ * handling during the release loop:
+ *
+ * When keepInterruptHoldoffCount = true (sub-transaction abort):
+ *   - Context: errfinish() has just reset InterruptHoldoffCount to 0
+ *   - Each RWLockRelease() call internally does RESUME_INTERRUPTS() (count -1)
+ *   - To prevent underflow, we HOLD_INTERRUPTS() (+1) before each release
+ *   - But we must ensure the final InterruptHoldoffCount equals the value
+ *     before this function was called (usually 0 after errfinish)
+ *   - Solution: Save InterruptHoldoffCount at entry, restore it at exit
+ *
+ * When keepInterruptHoldoffCount = false (main transaction commit):
+ *   - Normal HOLD/RESUME pairing is expected
+ *   - Each RWLockRelease() decrements InterruptHoldoffCount naturally
+ *   - No special handling needed
+ *
+ * Example scenario (sub-transaction abort):
+ *   PathParse: RWLockAcquire(lock1)        // InterruptHoldoffCount: 0 → 1
+ *   BeginInternalSubTransaction()          // savedCount = 1 recorded
+ *     InsertIntoInodeTable:
+ *       RWLockAcquire(lock2)               // InterruptHoldoffCount: 1 → 2
+ *       Unique key conflict → ERROR
+ *   errfinish():
+ *     InterruptHoldoffCount = 0            // ← Forcibly reset!
+ *     longjmp to PG_CATCH
+ *   SubXactCallback(ABORT_SUB):
+ *     RWLockReleaseSince(1, true):
+ *       savedInterruptHoldoffCount = 0     // Save current value
+ *       Loop iteration 1 (release lock2):
+ *         HOLD_INTERRUPTS()                // 0 → 1 (temporarily)
+ *         RWLockRelease(lock2)
+ *           RESUME_INTERRUPTS()            // 1 → 0 (inside RWLockRelease)
+ *       InterruptHoldoffCount = 0          // Restore saved value (no change)
+ *   Result: lock1 preserved, InterruptHoldoffCount = 0 ✓
+ */
+void RWLockReleaseSince(int savedCount, bool keepInterruptHoldoffCount)
+{
+    /* Validate savedCount is within reasonable range */
+    if (savedCount < 0 || savedCount > num_held_rwlocks)
+        FALCON_ELOG_ERROR_EXTENDED(PROGRAM_ERROR,
+                                    "invalid savedCount %d (num_held_rwlocks = %d)",
+                                    savedCount,
+                                    num_held_rwlocks);
+
+    /*
+     * Save InterruptHoldoffCount before the loop.
+     *
+     * Why save? Because each iteration does HOLD_INTERRUPTS() followed by
+     * RWLockRelease() (which does RESUME_INTERRUPTS()), causing the count
+     * to fluctuate. When keepInterruptHoldoffCount = true, we want to
+     * guarantee the count returns to its pre-loop value, regardless of
+     * how many locks are released or whether the loop exits normally.
+     *
+     * This is especially critical after errfinish() has reset the count
+     * to 0 - we must preserve that 0 value.
+     */
+    int savedInterruptHoldoffCount = InterruptHoldoffCount;
+
+    /*
+     * Use PG_FINALLY to guarantee InterruptHoldoffCount restoration even if
+     * an error occurs during lock release.
+     *
+     * Why PG_FINALLY instead of simple assignment after the loop?
+     *   1. Defense in depth: If RWLockRelease() throws an ERROR (e.g., "lock
+     *      is not held"), the FINALLY block still executes, preventing count
+     *      mismatch from propagating.
+     *
+     *   2. Clear intent: Using PG_FINALLY makes it explicit that we MUST restore
+     *      InterruptHoldoffCount regardless of how the function exits (normal
+     *      return, ERROR, or even FATAL).
+     *
+     *   3. PostgreSQL best practice: This follows the same pattern used
+     *      throughout PostgreSQL core for critical state restoration (e.g.,
+     *      CurrentMemoryContext, interrupt handling, etc.).
+     *
+     * Note: While errfinish() will also reset InterruptHoldoffCount to 0 on
+     * ERROR, using PG_FINALLY ensures our code is self-contained and doesn't
+     * rely on implicit error handling behavior. This makes the code more
+     * robust against future PostgreSQL changes.
+     */
+    PG_TRY();
+    {
+        /* Release locks in reverse order (most recently acquired first) */
+        while (num_held_rwlocks > savedCount) {
+            /*
+             * Always hold interrupts to offset the RESUME_INTERRUPTS() that will
+             * be called inside RWLockRelease() or RWLockUndeclare().
+             *
+             * Without this, each release would decrement InterruptHoldoffCount,
+             * potentially causing underflow. This applies regardless of
+             * keepInterruptHoldoffCount value:
+             *
+             * - When keepInterruptHoldoffCount=true (sub-tx abort after errfinish):
+             *   InterruptHoldoffCount may be 0, and we need to prevent underflow.
+             *
+             * - When keepInterruptHoldoffCount=false (main tx commit):
+             *   InterruptHoldoffCount starts at a positive value (from CommitTransaction's
+             *   HOLD_INTERRUPTS), and releasing multiple locks would cause underflow
+             *   without this offsetting HOLD_INTERRUPTS.
+             */
+            HOLD_INTERRUPTS();
+
+            if (held_rwlocks[num_held_rwlocks - 1].mode == RW_DECLARE)
+                RWLockUndeclare(held_rwlocks[num_held_rwlocks - 1].lock);
+            else
+                RWLockRelease(held_rwlocks[num_held_rwlocks - 1].lock);
+        }
+    }
+    PG_FINALLY();
+    {
+        /*
+         * Restore InterruptHoldoffCount to its pre-loop value.
+         *
+         * This is the key to keepInterruptHoldoffCount = true semantics:
+         * no matter what happened in the TRY block (normal execution, ERROR,
+         * or early exit due to assertion failure), this restore operation
+         * ensures InterruptHoldoffCount matches what it was when we entered.
+         *
+         * The FINALLY block guarantees this restoration happens even if:
+         *   - RWLockRelease() throws "lock is not held" error
+         *   - An assertion fails inside the loop
+         *   - A FATAL error occurs (though in that case the process dies anyway)
+         *
+         * For keepInterruptHoldoffCount = false, we skip this restore and
+         * let the natural RESUME_INTERRUPTS() calls take effect.
+         */
+        if (keepInterruptHoldoffCount)
+            InterruptHoldoffCount = savedInterruptHoldoffCount;
+    }
+    PG_END_TRY();
+}
+
+/*
  * RWLockReleaseAll - release all currently-held locks
  *
  * Used to clean up after ereport(ERROR). An important difference between this
@@ -192,13 +346,5 @@ void RWLockRelease(RWLock *lock)
  */
 void RWLockReleaseAll(bool keepInterruptHoldoffCount)
 {
-    while (num_held_rwlocks > 0) {
-        if (keepInterruptHoldoffCount)
-            HOLD_INTERRUPTS();
-
-        if (held_rwlocks[num_held_rwlocks - 1].mode == RW_DECLARE)
-            RWLockUndeclare(held_rwlocks[num_held_rwlocks - 1].lock);
-        else
-            RWLockRelease(held_rwlocks[num_held_rwlocks - 1].lock);
-    }
+    RWLockReleaseSince(0, keepInterruptHoldoffCount);
 }


### PR DESCRIPTION
## Summary

This MR contains two critical fixes for PostgreSQL 17 upgrade compatibility:

1. **Fix DN node core dump caused by `InterruptHoldoffCount > 0` assertion failure**
   - Issue: Sub-transaction error handling during concurrent same-file creation causes state inconsistency between InterruptHoldoffCount and RWLock tracking
   - Solution: Register `SubXactCallback` to release only sub-transaction-scoped RWLocks on abort, preserving parent-held path locks

2. **Fix `AssertHasSnapshotForToast` assertion failure causing startup crash**
   - Issue: PG17 requires active snapshot before modifying tables with TOAST, FalconFS metadata operations lack snapshot management
   - Solution: Add `PushActiveSnapshot`/`PopActiveSnapshot` around all catalog modification paths

---

## Issue 1: InterruptHoldoffCount Assertion Failure

### Background

During concurrent creation of files with the same name on two nodes, the DN node crashes with the following stack trace:

```
TRAP: FailedAssertion("InterruptHoldoffCount > 0", File: "xact.c", Line: 2390, PID: 264)

#3  ExceptionalCondition (conditionName="InterruptHoldoffCount > 0", ...) at assert.c:69
#4  CommitTransaction () at xact.c:2390
#5  CommitTransactionCommand () at xact.c:3048
```

The crash is triggered by `DFC_CREATE` when multiple processes attempt to create a file with the same name concurrently.
### Root Cause

The root cause is a state inconsistency between PostgreSQL's `InterruptHoldoffCount` and Falcon's `held_rwlocks` array during sub-transaction error handling.

**Execution flow:**

| Step | Operation | InterruptHoldoffCount | held_rwlocks |
|------|-----------|----------------------|--------------|
| 1 | PathParse: `RWLockAcquire()` | 0 → 1 | 0 → 1 |
| 2 | `BeginInternalSubTransaction()` | 1 | 1 |
| 3 | `InsertIntoInodeTable()` — unique key conflict triggers ERROR | 1 | 1 |
| 4 | **`errfinish()`: forcibly resets `InterruptHoldoffCount = 0`** | **1 → 0** | 1 (not cleaned!) |
| 5 | `PG_CATCH`: `RollbackAndReleaseCurrentSubTransaction()` | 0 | 1 |
| 6 | Main transaction continues and eventually COMMITs | 0 | 1 |
| 7 | `CommitTransaction()`: `HOLD_INTERRUPTS()` | 0 → 1 | 1 |
| 8 | `RWLockReleaseAll(false)`: releases the stale lock entry | 1 → 0 | 1 → 0 |
| 9 | `CommitTransaction()`: `RESUME_INTERRUPTS()` | **Assertion failure!** | 0 |

**Key point:** When an ERROR is thrown, PostgreSQL's `errfinish()` (elog.c:577) **forcibly resets `InterruptHoldoffCount` to 0** before longjmp-ing to PG_CATCH. However, Falcon's `held_rwlocks` array is not cleaned up, causing a count mismatch at main transaction commit.

### Solution

Register a `SubXactCallback` that tracks RWLock state across sub-transaction boundaries. Instead of calling `RWLockReleaseAll()` (which would unsafely release parent-held path locks such as those acquired during PHASE 1 of `CreateHandle`), we record the held lock count at sub-transaction start and only release locks acquired during the sub-transaction:

```c
#define MAX_SUB_XACT_DEPTH 16
static int subXactRWLockStack[MAX_SUB_XACT_DEPTH];
static int subXactRWLockStackTop = 0;

static void FalconSubTransactionCallback(SubXactEvent event, ...)
{
    switch (event) {
    case SUBXACT_EVENT_START_SUB:
        subXactRWLockStack[subXactRWLockStackTop++] = RWLockGetHeldCount();
        break;
    case SUBXACT_EVENT_ABORT_SUB:
        savedCount = subXactRWLockStack[--subXactRWLockStackTop];
        RWLockReleaseSince(savedCount, true);  // only release locks added during sub-tx
        break;
    case SUBXACT_EVENT_COMMIT_SUB:
        subXactRWLockStackTop--;
        break;
    }
}
```

**New APIs added to `rwlock.c`:**
- `RWLockGetHeldCount()` — returns current number of held RWLocks
- `RWLockReleaseSince(savedCount, keepInterruptHoldoffCount)` — releases only locks at indices >= savedCount

**Guarantees:**
1. Stale lock entries in `held_rwlocks` are cleaned up on sub-transaction abort
2. `keepInterruptHoldoffCount=true` preserves the current count (already reset to 0 by `errfinish()`)
3. Parent-held path locks (e.g. from `CreateHandle` PHASE 1) are **not** released, avoiding a concurrency window where other operations could modify a path while the handler still holds references to it
4. Nested sub-transactions are supported via a stack (up to 16 levels deep)

## Issue 2: AssertHasSnapshotForToast Assertion Failure

### Background

After upgrading to PostgreSQL 17, startup crashes when compiled with `--enable-cassert`:

```
TRAP: failed Assert("HaveRegisteredOrActiveSnapshot()"), File: "heapam.c", Line: 264
Failed process was running: SELECT falcon_plain_mkdir('/');
```

### Root Cause

**PG17 Change:** Commit `fe8ea7a2a89` (Nathan Bossart, 2024-05-30) added `AssertHasSnapshotForToast()` checks in `heap_insert`/`heap_delete`/`heap_update`/`heap_multi_insert`. If a table has a TOAST table (e.g., tables with `text`, `bytea` columns), an active snapshot must exist before modification operations.

**FalconFS Problem:**
- All metadata tables (`falcon_directory_table`, `falcon_inode_table`, `falcon_foreign_server`, `falcon_shard_table`, `falcon_distributed_transaction`) contain `text` columns
- They automatically have TOAST tables
- Code contains no `PushActiveSnapshot()`/`PopActiveSnapshot()` calls
- Assertion failure triggered

**Two trigger points:**

1. **SQL entry functions** — Functions directly called from SQL like `falcon_plain_mkdir('/')`
2. **Transaction commit callback** — `Write2PCRecord()` is called in `XACT_EVENT_PRE_COMMIT` callback, after main operation has already popped its snapshot

Call stack example (trigger point 2):
```
CommitTransactionCommand
  → FalconTransactionCallback (XACT_EVENT_PRE_COMMIT)
    → FalconRemoteCommandPrepare
      → Write2PCRecord
        → CatalogTupleInsert  ← No active snapshot!
```
### Solution

Add active snapshot management around all catalog modification operations (`CatalogTupleInsert`/`Delete`/`Update`).

**Fix Strategy:**

1. **SQL entry functions** — Wrap main operations
   ```c
   PushActiveSnapshot(GetTransactionSnapshot());
   MetaProcess(...);  // or FalconMkdirHandle, etc.
   PopActiveSnapshot();
   ```

2. **Catalog writes in transaction callbacks** — Independent snapshot management inside `Write2PCRecord`
   ```c
   void Write2PCRecord(int serverId, char *gid)
   {
       PushActiveSnapshot(GetTransactionSnapshot());
       Relation rel = table_open(...);
       CatalogTupleInsert(rel, heapTuple);
       table_close(rel, ...);
       PopActiveSnapshot();
   }
   ```

**Key Point:**
- `Write2PCRecord` is called in `XACT_EVENT_PRE_COMMIT` callback, after main operation's Push/Pop pair has completed
- Must manage snapshot independently inside the function
