### PR TITLE
fix(meta): initialize new file node_id to -1 instead of local server id

### DIFF
--- a/falcon/metadb/meta_handle.c
+++ b/falcon/metadb/meta_handle.c
@@ -452,7 +452,7 @@ void FalconCreateHandle(MetaProcessInfo *infoArray, int count, bool updateExiste
         info->st_atim = info->st_mtim;
         info->st_ctim = info->st_mtim;
         info->st_size = 0;
-        info->node_id = GetLocalServerId();
+        info->node_id = -1;
         info->st_nlink = 1;
         info->etag = (char *)"";
         info->st_dev = 0;


### PR DESCRIPTION
## Background

`FalconCreateHandle` initialized `info->node_id` with `GetLocalServerId()` when creating a new file.  
This effectively bound the file to the local metadata server during create time instead of keeping the node assignment unset.

## Problem

The store-side allocation path is triggered only when `openInstance->nodeId == -1`.  
If `node_id` is already set during create, the later store allocation step is skipped, and the metadata server id is incorrectly treated as the file's data node.

## Change

Changed the initialization in `FalconCreateHandle` from:

```c
info->node_id = GetLocalServerId();
```

to:

```c
info->node_id = -1;
```

This keeps newly created files in an unassigned state so the store layer can allocate the data node through the existing `nodeId == -1` path.

## Impact

- Restores the intended semantics for new file `node_id`
- Avoids prematurely binding files to the local metadata server id
- Keeps metadata behavior consistent with the existing store-side allocation logic
