### PR TITLE
fix(falcon_cm): prevent watch starvation and unblock CN supplement recovery chain

### DIFF
--- a/cloud_native/falcon_cm/cm/falcon_cm.py
+++ b/cloud_native/falcon_cm/cm/falcon_cm.py
@@ -541,22 +541,10 @@ class FalconCM:
             self.logger.info(
                 "[reconcile] leader path not found epoch={}".format(epoch)
             )
-            return
+            return "stale"
         data, _ = self._zk_client.get(leader_path)
         ip_port = data.decode("utf-8")
         leader_ip, _ = ip_port.split(":", 1)
-        try:
-            self.delete_candidates()
-        except Exception:
-            pass
-        try:
-            self._zk_client.delete(
-                "{}/{}/replicas/{}".format(
-                    self._cluster_path, self._cluster_name, ip_port
-                )
-                )
-        except Exception:
-            pass
         self._cluster_leader_ip = leader_ip
         self._is_leader = leader_ip == self._pod_ip
         self.logger.info(
@@ -566,11 +554,26 @@ class FalconCM:
         self._is_changing = True
         try:
             if leader_ip == self._pod_ip:
+                if self.is_reconcile_stale(epoch):
+                    return "stale"
+                try:
+                    self.delete_candidates()
+                except Exception:
+                    pass
+                try:
+                    self._zk_client.delete(
+                        "{}/{}/replicas/{}".format(
+                            self._cluster_path, self._cluster_name, ip_port
+                        )
+                    )
+                except Exception:
+                    pass
+
                 if self._is_cn:
                     self.watch_need_supplement()
                 self.watch_replicas()
                 if self.is_reconcile_stale(epoch):
-                    return
+                    return "stale"
                 if postgresql.is_standby(self._pgdata_dir):
                     postgresql.do_promote(
                         self._pgdata_dir,
@@ -581,13 +584,13 @@ class FalconCM:
                         self._pod_ip,
                     )
                 if self.is_reconcile_stale(epoch):
-                    return
+                    return "stale"
 
                 ret = False
                 retry = 0
                 while not ret and self._thread_running:
                     if self.is_reconcile_stale(epoch):
-                        return
+                        return "stale"
                     self.logger.info(
                         "[reconcile] phase=update_background epoch={} retry={}".format(
                             epoch, retry
@@ -601,17 +604,20 @@ class FalconCM:
                         break
                     retry += 1
                     if self.is_reconcile_stale(epoch):
-                        return
+                        return "stale"
                     time.sleep(1)
 
+                if not self._thread_running:
+                    return "stale"
+
                 if self.is_reconcile_stale(epoch):
-                    return
+                    return "stale"
                 cn_leader_ip = self.get_cn_leader()
                 ret = False
                 retry = 0
                 while not ret and self._thread_running:
                     if self.is_reconcile_stale(epoch):
-                        return
+                        return "stale"
                     self.logger.info(
                         "[reconcile] phase=update_node_table epoch={} retry={}"
                         .format(epoch, retry)
@@ -632,10 +638,15 @@ class FalconCM:
                         break
                     retry += 1
                     if self.is_reconcile_stale(epoch):
-                        return
+                        return "stale"
                     cn_leader_ip = self.get_cn_leader()
                     time.sleep(1)
+
+                if not self._thread_running:
+                    return "stale"
+
                 self.logger.info("[reconcile] success epoch={}".format(epoch))
+                return "done"
             else:
                 try:
                     self._zk_client.delete(
@@ -676,6 +687,7 @@ class FalconCM:
                         self._cluster_path, self._cluster_name, self._host_node_name
                     )
                 )
+                return "done"
         finally:
             self._is_changing = False
 
@@ -691,15 +703,28 @@ class FalconCM:
                     self._leader_reconcile_event.clear()
                     self._leader_reconcile_lock.release()
                     break
-                self._leader_reconcile_handled_epoch = epoch
                 self._leader_reconcile_lock.release()
+                result = "retry"
                 try:
-                    self.run_leader_reconcile(epoch)
+                    result = self.run_leader_reconcile(epoch)
                 except Exception as ex:
                     self.logger.error(
                         "[reconcile] failed epoch={} err={} trace={}"
                         .format(epoch, ex, traceback.format_exc())
                     )
+                    result = "retry"
+
+                if result == "retry":
+                    time.sleep(1)
+                    self._leader_reconcile_event.set()
+                    continue
+
+                self._leader_reconcile_lock.acquire()
+                if epoch > self._leader_reconcile_handled_epoch:
+                    self._leader_reconcile_handled_epoch = epoch
+                if self._leader_reconcile_epoch <= self._leader_reconcile_handled_epoch:
+                    self._leader_reconcile_event.clear()
+                self._leader_reconcile_lock.release()
 
     def handle_candidate_change_event(self, candidates):
         leader_path = "{}/{}".format(self._leader_path, self._cluster_name)

--- a/cloud_native/falcon_cm/cm/falcon_cm.py
+++ b/cloud_native/falcon_cm/cm/falcon_cm.py
@@ -29,9 +29,18 @@ class FalconCM:
         self._lost_node_time = {}
         self._watch_replica_lock = threading.Lock()
         self._watch_need_supplement_lock = threading.Lock()
+        self._watch_register_lock = threading.Lock()
         self._replica_change_num = 0
         self._need_supplement_num = 0
         self._thread_running = True
+        self._leader_reconcile_running = True
+        self._leader_reconcile_event = threading.Event()
+        self._leader_reconcile_lock = threading.Lock()
+        self._leader_reconcile_epoch = 0
+        self._leader_reconcile_handled_epoch = 0
+        self._leader_reconcile_thread = None
+        self._need_supp_watch_started = False
+        self._replica_watch_started = False
         self._is_cn = is_cn
         self._cluster_name = None
         self._cn_list = []
@@ -42,6 +51,8 @@ class FalconCM:
 
     def __del__(self):
         self._thread_running = False
+        self._leader_reconcile_running = False
+        self._leader_reconcile_event.set()
 
     def init_falcon_env(self):
         self._hosts = os.environ.get("zk_endpoint")
@@ -431,6 +442,8 @@ class FalconCM:
                     self.handle_leader_delete_event()
                 elif event.type == EventType.CREATED:
                     self.handle_leader_create_event()
+                elif event.type == EventType.CHANGED:
+                    self.enqueue_leader_reconcile("leader_changed")
 
         @self._zk_client.ChildrenWatch(candidates_path)
         def watch_candidates(candidates):
@@ -481,7 +494,54 @@ class FalconCM:
             self._zk_client.delete(child_path)
 
     def handle_leader_create_event(self):
+        self.enqueue_leader_reconcile("leader_created")
+
+    def enqueue_leader_reconcile(self, reason):
+        self._leader_reconcile_lock.acquire()
+        self._leader_reconcile_epoch += 1
+        epoch = self._leader_reconcile_epoch
+        self._leader_reconcile_lock.release()
+        self.logger.info(
+            "[reconcile] enqueue epoch={} reason={}".format(epoch, reason)
+        )
+        self._leader_reconcile_event.set()
+
+    def is_current_cluster_leader(self):
         leader_path = "{}/{}".format(self._leader_path, self._cluster_name)
+        try:
+            if not self._zk_client.exists(leader_path):
+                return False
+            data, _ = self._zk_client.get(leader_path)
+            ip_port = data.decode("utf-8")
+            leader_ip, _ = ip_port.split(":", 1)
+            return leader_ip == self._pod_ip
+        except Exception as ex:
+            self.logger.error(
+                "[reconcile] failed to get current leader: {}".format(ex)
+            )
+            return False
+
+    def is_reconcile_stale(self, epoch):
+        self._leader_reconcile_lock.acquire()
+        current_epoch = self._leader_reconcile_epoch
+        self._leader_reconcile_lock.release()
+        if epoch != current_epoch:
+            self.logger.info(
+                "[reconcile] stale epoch={} current={}".format(epoch, current_epoch)
+            )
+            return True
+        if not self.is_current_cluster_leader():
+            self.logger.info("[reconcile] exit not leader epoch={}".format(epoch))
+            return True
+        return False
+
+    def run_leader_reconcile(self, epoch):
+        leader_path = "{}/{}".format(self._leader_path, self._cluster_name)
+        if not self._zk_client.exists(leader_path):
+            self.logger.info(
+                "[reconcile] leader path not found epoch={}".format(epoch)
+            )
+            return
         data, _ = self._zk_client.get(leader_path)
         ip_port = data.decode("utf-8")
         leader_ip, _ = ip_port.split(":", 1)
@@ -494,97 +554,152 @@ class FalconCM:
                 "{}/{}/replicas/{}".format(
                     self._cluster_path, self._cluster_name, ip_port
                 )
-            )
+                )
         except Exception:
             pass
         self._cluster_leader_ip = leader_ip
+        self._is_leader = leader_ip == self._pod_ip
         self.logger.info(
             "The leader of the cluster {} is {}".format(self._cluster_name, leader_ip)
         )
+        self.logger.info("[reconcile] start epoch={}".format(epoch))
         self._is_changing = True
-        if leader_ip == self._pod_ip:
-            if self._is_cn:
-                self.watch_need_supplement()
-            self.watch_replicas()
-            if postgresql.is_standby(self._pgdata_dir):
-                postgresql.do_promote(
-                    self._pgdata_dir,
-                    self._pod_ip,
-                    self._meta_port,
-                    self._user_name,
-                    self._node_ip,
-                    self._pod_ip,
-                )
+        try:
+            if leader_ip == self._pod_ip:
+                if self._is_cn:
+                    self.watch_need_supplement()
+                self.watch_replicas()
+                if self.is_reconcile_stale(epoch):
+                    return
+                if postgresql.is_standby(self._pgdata_dir):
+                    postgresql.do_promote(
+                        self._pgdata_dir,
+                        self._pod_ip,
+                        self._meta_port,
+                        self._user_name,
+                        self._node_ip,
+                        self._pod_ip,
+                    )
+                if self.is_reconcile_stale(epoch):
+                    return
 
-            ret = False
-            while not ret:
-                self.logger.info("--update background service--")
-                ret = postgresql.update_start_background_service(
-                    self._cluster_leader_ip, self._meta_port, self._user_name
-                )
-                if ret:
-                    break
-                time.sleep(1)
-            self.logger.info("--update background service successfully--")
-            cn_leader_ip = self.get_cn_leader()
-            ret = False
-            while not ret:
-                self.logger.info("--update the node table--")
-                ret = postgresql.update_node_table(
-                    cn_leader_ip,
-                    self._meta_port,
-                    self._user_name,
-                    self._cluster_id,
-                    self._cluster_leader_ip,
-                    self._meta_port,
-                )
-                postgresql.reload_foreign_server_cache(
-                    cn_leader_ip, self._meta_port, self._user_name
-                )
-                if ret:
-                    break
+                ret = False
+                retry = 0
+                while not ret and self._thread_running:
+                    if self.is_reconcile_stale(epoch):
+                        return
+                    self.logger.info(
+                        "[reconcile] phase=update_background epoch={} retry={}".format(
+                            epoch, retry
+                        )
+                    )
+                    ret = postgresql.update_start_background_service(
+                        self._cluster_leader_ip, self._meta_port, self._user_name
+                    )
+                    if ret:
+                        self.logger.info("--update background service successfully--")
+                        break
+                    retry += 1
+                    if self.is_reconcile_stale(epoch):
+                        return
+                    time.sleep(1)
+
+                if self.is_reconcile_stale(epoch):
+                    return
                 cn_leader_ip = self.get_cn_leader()
-                time.sleep(1)
-            self.logger.info("--update the node table successfully--")
-        else:
-            try:
-                self._zk_client.delete(
+                ret = False
+                retry = 0
+                while not ret and self._thread_running:
+                    if self.is_reconcile_stale(epoch):
+                        return
+                    self.logger.info(
+                        "[reconcile] phase=update_node_table epoch={} retry={}"
+                        .format(epoch, retry)
+                    )
+                    ret = postgresql.update_node_table(
+                        cn_leader_ip,
+                        self._meta_port,
+                        self._user_name,
+                        self._cluster_id,
+                        self._cluster_leader_ip,
+                        self._meta_port,
+                    )
+                    postgresql.reload_foreign_server_cache(
+                        cn_leader_ip, self._meta_port, self._user_name
+                    )
+                    if ret:
+                        self.logger.info("--update the node table successfully--")
+                        break
+                    retry += 1
+                    if self.is_reconcile_stale(epoch):
+                        return
+                    cn_leader_ip = self.get_cn_leader()
+                    time.sleep(1)
+                self.logger.info("[reconcile] success epoch={}".format(epoch))
+            else:
+                try:
+                    self._zk_client.delete(
+                        "{}/{}/membership/{}".format(
+                            self._cluster_path,
+                            self._cluster_name,
+                            self._host_node_name,
+                        )
+                    )
+                except NoNodeError:
+                    pass
+                if postgresql.is_standby(self._pgdata_dir):
+                    postgresql.change_following_leader(
+                        self._pgdata_dir,
+                        self._cluster_leader_ip,
+                        self._meta_port,
+                        self._user_name,
+                        self._pod_ip,
+                        self._meta_port,
+                        self._host_node_name,
+                        self._node_ip,
+                        self._pod_ip,
+                    )
+                else:
+                    postgresql.do_demote(
+                        self._pgdata_dir,
+                        self._cluster_leader_ip,
+                        self._meta_port,
+                        self._user_name,
+                        self._pod_ip,
+                        self._meta_port,
+                        self._host_node_name,
+                        self._node_ip,
+                        self._pod_ip,
+                    )
+                self._zk_client.create(
                     "{}/{}/membership/{}".format(
                         self._cluster_path, self._cluster_name, self._host_node_name
                     )
                 )
-            except NoNodeError:
-                pass
-            if postgresql.is_standby(self._pgdata_dir):
-                postgresql.change_following_leader(
-                    self._pgdata_dir,
-                    self._cluster_leader_ip,
-                    self._meta_port,
-                    self._user_name,
-                    self._pod_ip,
-                    self._meta_port,
-                    self._host_node_name,
-                    self._node_ip,
-                    self._pod_ip,
-                )
-            else:
-                postgresql.do_demote(
-                    self._pgdata_dir,
-                    self._cluster_leader_ip,
-                    self._meta_port,
-                    self._user_name,
-                    self._pod_ip,
-                    self._meta_port,
-                    self._host_node_name,
-                    self._node_ip,
-                    self._pod_ip,
-                )
-            self._zk_client.create(
-                "{}/{}/membership/{}".format(
-                    self._cluster_path, self._cluster_name, self._host_node_name
-                )
-            )
-        self._is_changing = False
+        finally:
+            self._is_changing = False
+
+    def leader_reconcile_loop(self):
+        while self._thread_running and self._leader_reconcile_running:
+            is_notified = self._leader_reconcile_event.wait(timeout=1)
+            if not is_notified:
+                continue
+            while self._thread_running and self._leader_reconcile_running:
+                self._leader_reconcile_lock.acquire()
+                epoch = self._leader_reconcile_epoch
+                if epoch <= self._leader_reconcile_handled_epoch:
+                    self._leader_reconcile_event.clear()
+                    self._leader_reconcile_lock.release()
+                    break
+                self._leader_reconcile_handled_epoch = epoch
+                self._leader_reconcile_lock.release()
+                try:
+                    self.run_leader_reconcile(epoch)
+                except Exception as ex:
+                    self.logger.error(
+                        "[reconcile] failed epoch={} err={} trace={}"
+                        .format(epoch, ex, traceback.format_exc())
+                    )
 
     def handle_candidate_change_event(self, candidates):
         leader_path = "{}/{}".format(self._leader_path, self._cluster_name)
@@ -781,8 +896,13 @@ class FalconCM:
         watch_replica_thread = threading.Thread(
             target=FalconCM.handle_replica_change, args=(self,)
         )
+        self._leader_reconcile_thread = threading.Thread(
+            target=FalconCM.leader_reconcile_loop, args=(self,)
+        )
         watch_replica_thread.start()
+        self._leader_reconcile_thread.start()
         watch_replica_thread.join()
+        self._leader_reconcile_thread.join()
 
     def start_watch_replica_need_supplement_thread(self):
         watch_replica_thread = threading.Thread(
@@ -794,12 +914,17 @@ class FalconCM:
         check_meta_status_thread = threading.Thread(
             target=FalconCM.handle_meta_error_report, args=(self,)
         )
+        self._leader_reconcile_thread = threading.Thread(
+            target=FalconCM.leader_reconcile_loop, args=(self,)
+        )
         watch_replica_thread.start()
         handle_replica_thread.start()
         check_meta_status_thread.start()
+        self._leader_reconcile_thread.start()
         watch_replica_thread.join()
         handle_replica_thread.join()
         check_meta_status_thread.join()
+        self._leader_reconcile_thread.join()
 
     def handle_replica_change(self):
         while self._thread_running:
@@ -977,6 +1102,13 @@ class FalconCM:
             time.sleep(self._check_meta_period)
 
     def watch_need_supplement(self):
+        self._watch_register_lock.acquire()
+        if self._need_supp_watch_started:
+            self._watch_register_lock.release()
+            return
+        self._need_supp_watch_started = True
+        self._watch_register_lock.release()
+
         @self._zk_client.ChildrenWatch(self._need_supplement_path)
         def watch_nodes(children):
             self.logger.info("in need supplement watch")
@@ -985,6 +1117,13 @@ class FalconCM:
             self._watch_need_supplement_lock.release()
 
     def watch_replicas(self):
+        self._watch_register_lock.acquire()
+        if self._replica_watch_started:
+            self._watch_register_lock.release()
+            return
+        self._replica_watch_started = True
+        self._watch_register_lock.release()
+
         replica_path = "{}/{}/replicas".format(self._cluster_path, self._cluster_name)
 
         @self._zk_client.ChildrenWatch(replica_path)


### PR DESCRIPTION
Fixes #90
## 背景 
`falcon_cm` 在早期实现中，`handle_leader_create_event()` 直接执行整段 leader reconcile（promote + update_background + update_node_table 等），属于同步长路径。
- 旧行为（历史版本）：`handle_leader_create_event` 直接跑重逻辑  
- 改造后（checkpoint 可追溯）：`handle_leader_create_event -> enqueue_leader_reconcile("leader_created")`，由独立 `leader_reconcile_loop` 消费执行  
  参考：`cloud_native/falcon_cm/cm/falcon_cm.py:496-507`、`cloud_native/falcon_cm/cm/falcon_cm.py:694-727`
## 问题陈述
1. 为什么必须从“同步回调”改成“异步队列”；
2. 改造后保证了什么；
## 变更动机
同步回调模式下，`DataWatch` 回调线程可能被长时间占用（例如 `update_node_table` 重试环），导致其他 watch 事件处理不及时，表现为：
- 事件调度饥饿（例如 `need_supplement` 相关观察延后）；
- 控制面响应与收敛时序混淆；
- 故障注入场景下可观测性差，难以判定是系统问题还是回调阻塞问题。
## 改造内容（已实现）
- `handle_leader_create_event()` 只负责 enqueue，不再直接执行重逻辑；
- 新增 reconcile 事件与循环：
  - `enqueue_leader_reconcile(reason)`
  - `leader_reconcile_loop()`
  - `run_leader_reconcile(epoch)`
- 新增 `leader znode CHANGED` 入队；
- 引入 epoch/stale 判定用于 latest-wins 控制面收敛。
## 行为边界
- Watch 回调不再承载长执行路径，避免同步阻塞。
- Reconcile 可被串行消费并记录 enqueue/start/success/stale 日志。
- 发生 leader 变更时有统一入队路径，便于追踪。
## 当前线程调度关系
### 修改前：
[启动]
FalconCM.__init__/start
  ├─ Thread A: handle_replica_change()
  ├─ Thread B: handle_need_supplement()
  └─ 注册 watch_leader_and_candidates()
       ├─ DataWatch(leader) -> watch_leader(...)
       │    └─ handle_leader_create_event()   <-- 当前重逻辑在回调线程
       │         ├─ watch_need_supplement()   (注册ChildrenWatch)
       │         ├─ watch_replicas()
       │         ├─ do_promote()
       │         ├─ while !ret: update_start_background_service()
       │         └─ while !ret: update_node_table() + reload_cache()
       └─ ChildrenWatch(candidates) -> handle_candidate_change_event()
[补副本触发链]
Thread A: handle_replica_change()
  └─ check_all_nodes_status()
       └─ create /falcon/need_supplement/cn-0
[补副本消费链]
ChildrenWatch(need_supplement) -> watch_nodes()
  └─ _need_supplement_num += 1
Thread B: handle_need_supplement()
  └─ if _need_supplement_num > 0:
       ├─ get_children(/need_supplement)
       ├─ 从 /cn_supplement 取节点
       ├─ 写入 cluster/hostNodes
       └─ delete /need_supplement/cn-0
### 修改后
每个 CN 容器内（独立进程）：
Main Thread
  ├─ start_watch_replica_need_supplement_thread()
  │   ├─ Thread-A: handle_replica_change
  │   ├─ Thread-B: handle_need_supplement
  │   ├─ Thread-C: handle_meta_error_report
  │   └─ Thread-D: leader_reconcile_loop   <-- 新增
  │
  └─ 注册 Kazoo Watchers
      ├─ DataWatch(/leaders/<cluster>) callback thread
      │    ├─ DELETED -> handle_leader_delete_event()
      │    └─ CREATED/CHANGED -> enqueue_leader_reconcile()
      │                         (epoch++ + event.set，快速返回)
      │
      ├─ ChildrenWatch(/need_supplement)
      │    └─ _need_supplement_num += 1
      │
      └─ ChildrenWatch(/replicas)
           └─ _replica_change_num += 1
Thread-D leader_reconcile_loop
  wait(event) -> 读取最新epoch -> run_leader_reconcile(epoch)
    ├─ stale检查(epoch/leader)
    ├─ promote(如需要)
    ├─ update_start_background_service 重试
    └─ update_node_table + reload_cache 重试
       (阶段边界持续 stale 检查)
Thread-A handle_replica_change
  消费 _replica_change_num
  -> check_all_nodes_status
  -> 创建 /need_supplement/*
Thread-B handle_need_supplement
  消费 _need_supplement_num
  -> 从 /cn_supplement or /dn_supplement 取节点
  -> 写 hostNodes
  -> 删除 /need_supplement/*
## 验证·：双副本集群拉起后，停掉 leader 并长时间挂起（S06）

> 说明：`chaos_run.log` 使用本地时区（17:xx），`cmlog` 常见容器时区（09:xx / 14:xx），两者约相差 8 小时。

---

## 修改前（旧实现）

### 1) 初始角色与节点
- `cn1 = 172.18.0.11`
- `cn2 = 172.18.0.12`
- `cn3 = 172.18.0.13`

**初始日志：**
```log
2026-04-03 09:35:29,276 - logger - INFO - This node is cn leader        # cn3
2026-04-03 09:35:29,229 - logger - INFO - This node is cn follower      # cn1
2026-04-03 09:35:29,225 - logger - INFO - This node is cn follower      # cn2
2026-04-03 09:36:00,234 - logger - INFO - The node cn-2 is not in any cluster, add it to the supplement cluster
```

> **解析总结**：leader=cn3，follower=cn1，supplement池可用节点=cn2。

---

### 2) 时间链路：

**T1：注入动作（打下线的是原 leader cn3）**
```log
[2026-04-03 17:37:04] [1] inject S06 stop cn leader then start after hold
[2026-04-03 17:37:07] falcon-cn-3 stopped, hold 95s for supplement observation
```
*JSON 侧证据：*
```json
"target": "falcon-cn-3:hold=95s",
"leader_before": {"cn":"172.18.0.13", ...}
```

**T2：切主成功（cn1 接管 leader）**
```log
2026-04-03 09:37:15,332 - logger - INFO - The leader of the cluster cn is 172.18.0.11
2026-04-03 09:37:15,333 - logger - INFO - Promote the DB to primary
2026-04-03 09:37:15,435 - logger - INFO - Promote the DB to primary successfully.
```
*JSON 也显示切主：*
```json
"leader_before":{"cn":"172.18.0.13"},
"leader_after":{"cn":"172.18.0.11"}
```

**T3：新 leader(cn1) 进入 update_node_table 长循环并卡住窗口**
```log
2026-04-03 09:37:15,468 - logger - INFO - --update the node table--
2026-04-03 09:37:20,031 - logger - INFO - lost time is 0
2026-04-03 09:37:30,034 - logger - INFO - lost time is 10
2026-04-03 09:37:40,036 - logger - INFO - lost time is 20
2026-04-03 09:37:50,038 - logger - INFO - lost time is 30
2026-04-03 09:38:00,040 - logger - INFO - lost time is 40
2026-04-03 09:38:10,042 - logger - INFO - lost time is 50
2026-04-03 09:38:10,043 - logger - INFO - The node cn-3 is lost, please check the status
```

**T4：补副本请求已产生，但服务长期 WRITE_BLOCKED 并超时失败**
*need_supplement 证据：*
```text
[cn-0]
```
*服务探针持续 pending：*
```log
[2026-04-03 17:39:44] service recovery pending ... observed=WRITE_BLOCKED ...
...
[2026-04-03 17:44:31] service recovery pending ... observed=WRITE_BLOCKED ...
[2026-04-03 17:44:38] [1] FAIL: service probe timeout ...
```
*最终 JSON 判定：*
```json
"recovered": false,
"service_observed": "WRITE_BLOCKED",
"stage_failed": "service",
"need_supplement_seen": true
```

---

## 修改后（新实现）

### 1) 验证结果（S06 通过）
```json
{
  "ts": 1775142146, 
  "index": 7, 
  "action_id": "S06", 
  "action": "stop cn leader then start after hold", 
  "target": "falcon-cn-1:hold=90s", 
  "injected": true, 
  "recovered": true, 
  "recover_seconds": 87, 
  "leader_before": {"cn": "172.18.0.11", "dn": "dn0=172.18.0.22"}, 
  "leader_after": {"cn": "172.18.0.13", "dn": "dn0=172.18.0.22"}
}
```

### 2) cm3 关键日志（补副本链路打通）
```log
2026-04-02 14:59:35,331 - logger - INFO - [reconcile] enqueue epoch=1 reason=leader_created
2026-04-02 14:59:35,332 - logger - INFO - The leader of the cluster cn is 172.18.0.13
2026-04-02 14:59:35,332 - logger - INFO - [reconcile] start epoch=1
...
2026-04-02 14:59:35,465 - logger - INFO - [reconcile] phase=update_node_table epoch=1 retry=0
2026-04-02 14:59:41,401 - logger - INFO - lost time is 0
2026-04-02 14:59:51,403 - logger - INFO - lost time is 10
2026-04-02 15:00:01,405 - logger - INFO - lost time is 20
2026-04-02 15:00:11,406 - logger - INFO - lost time is 30
2026-04-02 15:00:21,408 - logger - INFO - lost time is 40
2026-04-02 15:00:31,410 - logger - INFO - lost time is 50
2026-04-02 15:00:31,411 - logger - INFO - The node cn-1 is lost, please check the status
2026-04-02 15:00:41,401 - logger - INFO - The node cn-0 is need to supplement
2026-04-02 15:00:41,404 - logger - INFO - The node cn-2 is added to the cluster cn
2026-04-02 15:00:41,405 - logger - INFO - delete cn-0 in need supplement
2026-04-02 15:01:03,301 - logger - INFO - --update the node table successfully--
2026-04-02 15:01:03,301 - logger - INFO - [reconcile] success epoch=1
```

---

## 结论
- **修改前**：切主可以成功，但在补副本闭环前服务长期 `WRITE_BLOCKED`，超时失败。
- **修改后**：同类场景下补副本链路可闭环，`reconcile` 成功并恢复读写。
- **总结**：补副本链路已成功打通。