### PR TITLE
Compatibility with GCC 11.4.0 compilation

### DIFF
--- a/falcon_store/src/connection/node.cpp
+++ b/falcon_store/src/connection/node.cpp
@@ -109,13 +109,8 @@ void StoreNode::UpdateNodeConfigByValue(std::unordered_map<int, std::string> &zk
 
 int StoreNode::SetNodeConfig(std::string &rootPath)
 {
-    auto ipPort = GetPodIPPort();
-    if (!ipPort) {
-        FALCON_LOG(LOG_ERROR) << "GetPodIPPort failed: " << ipPort.error();
-        return -1; // 或定义明确的错误码
-    }
-    std::string podIP = ipPort.value_or("127.0.0.1:56039");
-    int ret = FalconCM::GetInstance()->Upload("", podIP, nodeId, rootPath);
+    std::string podIPPort = GetPodIPPort();
+    int ret = FalconCM::GetInstance()->Upload("", podIPPort, nodeId, rootPath);
     if (ret != 0) {
         return ret;
     }
@@ -195,14 +190,17 @@ int StoreNode::GetNodeId() { return nodeId; }
 int StoreNode::GetNodeId(std::string_view ipPort)
 {
     std::shared_lock<std::shared_mutex> slock(nodeMutex);
-    return SplitIp(ipPort)
-        .and_then([this](const auto &metaIp) {
-            auto it = std::find_if(nodeMap.begin(), nodeMap.end(), [&metaIp](const auto &entry) {
-                return SplitIp(entry.second.first) == metaIp;
-            });
-            return it != nodeMap.end() ? std::optional(it->first) : std::nullopt;
-        })
-        .value_or(-1);
+    auto metaIp = SplitIp(ipPort);
+    if (!metaIp.has_value()) {
+        return -1;
+    }
+    auto it = std::find_if(nodeMap.begin(), nodeMap.end(), [&metaIp](const auto &entry) {
+        return SplitIp(entry.second.first) == metaIp;
+    });
+    if (it == nodeMap.end()) {
+        return -1;
+    }
+    return it->first;
 }
 
 bool StoreNode::IsLocal(int otherNodeId)

--- a/falcon_store/src/include/util/utils.h
+++ b/falcon_store/src/include/util/utils.h
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <cstdlib>
-#include <expected>
 #include <optional>
 #include <string>
 
@@ -42,6 +41,6 @@ std::string GetFilePath(uint64_t inodeId);
 int GenerateRandom(int minValue, int maxValue);
 std::optional<std::string> GetUserName();
 std::optional<std::string_view> SplitIp(std::string_view ipPort);
-std::expected<std::string, std::string> GetPodIPPort();
+std::string GetPodIPPort();
 float GetStorageThreshold(bool persistToStorage);
 int GetParentPathLevel();

--- a/falcon_store/src/util/utils.cpp
+++ b/falcon_store/src/util/utils.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <random>
 
+#include "log/logging.h"
+
 std::string rootPath;
 int totalDirectory;
 uint32_t FALCON_BLOCK_SIZE;
@@ -41,13 +43,15 @@ std::optional<std::string> GetUserName()
 
 std::optional<std::string_view> SplitIp(std::string_view ipPort) { return ipPort.substr(0, ipPort.find(':')); }
 
-std::expected<std::string, std::string> GetPodIPPort()
+std::string GetPodIPPort()
 {
+    constexpr char defaultPodIPPort[] = "127.0.0.1:56039";
     if (const char *podIP = std::getenv("POD_IP")) {
         const char *brpcPort = std::getenv("BRPC_PORT");
         return std::string(podIP) + ":" + (brpcPort ? brpcPort : "56039");
     }
-    return std::unexpected("POD_IP environment variable not set");
+    FALCON_LOG(LOG_WARNING) << "POD_IP environment variable not set, use default pod IP: " << defaultPodIPPort;
+    return std::string(defaultPodIPPort);
 }
 
 float GetStorageThreshold(bool persistToStorage)


### PR DESCRIPTION
- 移除std::expected，同时重构 GetPodIPPort 的语义和调用处
- 将 GetNodeId(std::string_view) 的链式 optional 逻辑（std::optional::and_then函数）重构为显式判空与查找流程