### PR TITLE
fix: support openEuler release runtime with prebuilt RPM deps

### DIFF
--- a/cloud_native/docker_build/cn/check_liveness.sh
+++ b/cloud_native/docker_build/cn/check_liveness.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pg_isready -d postgres -U falconMeta --timeout=5 --quiet
+pg_isready -h 127.0.0.1 -p 5432 -d postgres -U falconMeta --timeout=5 --quiet
 if [ $? != 0 ]; then
     exit 1;
 fi

--- a/cloud_native/docker_build/cn/start.sh
+++ b/cloud_native/docker_build/cn/start.sh
@@ -3,8 +3,23 @@
 # 设置默认的安装目录
 FALCONFS_INSTALL_DIR=${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}
 
-export PATH=/usr/local/pgsql/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/pgsql/lib:${FALCONFS_INSTALL_DIR}/falcon_meta/lib:/usr/local/obs/lib
+PG_BIN_DIR=${FALCON_PG_BIN_DIR:-}
+PG_LIB_DIR=${FALCON_PG_LIB_DIR:-}
+if [ -z "${PG_BIN_DIR}" ] || [ -z "${PG_LIB_DIR}" ]; then
+    if command -v pg_config >/dev/null 2>&1; then
+        [ -z "${PG_BIN_DIR}" ] && PG_BIN_DIR="$(pg_config --bindir)"
+        [ -z "${PG_LIB_DIR}" ] && PG_LIB_DIR="$(pg_config --libdir)"
+    fi
+fi
+
+PG_BIN_DIR=${PG_BIN_DIR:-/usr/local/pgsql/bin}
+PG_LIB_DIR=${PG_LIB_DIR:-/usr/local/pgsql/lib}
+
+export PATH=${PG_BIN_DIR}:$PATH
+export LD_LIBRARY_PATH=${PG_LIB_DIR}:${FALCONFS_INSTALL_DIR}/falcon_meta/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+if [ -d /usr/local/obs/lib ]; then
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/obs/lib
+fi
 DATA_DIR=${FALCONFS_INSTALL_DIR}/data
 METADATA_DIR=${DATA_DIR}/metadata
 

--- a/cloud_native/docker_build/dn/check_liveness.sh
+++ b/cloud_native/docker_build/dn/check_liveness.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pg_isready -d postgres -U falconMeta --timeout=5 --quiet
+pg_isready -h 127.0.0.1 -p 5432 -d postgres -U falconMeta --timeout=5 --quiet
 if [ $? != 0 ]; then
     exit 1;
 fi

--- a/cloud_native/docker_build/dn/start.sh
+++ b/cloud_native/docker_build/dn/start.sh
@@ -3,8 +3,23 @@
 # 设置默认的安装目录
 FALCONFS_INSTALL_DIR=${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}
 
-export PATH=/usr/local/pgsql/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/pgsql/lib:${FALCONFS_INSTALL_DIR}/falcon_meta/lib:/usr/local/obs/lib
+PG_BIN_DIR=${FALCON_PG_BIN_DIR:-}
+PG_LIB_DIR=${FALCON_PG_LIB_DIR:-}
+if [ -z "${PG_BIN_DIR}" ] || [ -z "${PG_LIB_DIR}" ]; then
+    if command -v pg_config >/dev/null 2>&1; then
+        [ -z "${PG_BIN_DIR}" ] && PG_BIN_DIR="$(pg_config --bindir)"
+        [ -z "${PG_LIB_DIR}" ] && PG_LIB_DIR="$(pg_config --libdir)"
+    fi
+fi
+
+PG_BIN_DIR=${PG_BIN_DIR:-/usr/local/pgsql/bin}
+PG_LIB_DIR=${PG_LIB_DIR:-/usr/local/pgsql/lib}
+
+export PATH=${PG_BIN_DIR}:$PATH
+export LD_LIBRARY_PATH=${PG_LIB_DIR}:${FALCONFS_INSTALL_DIR}/falcon_meta/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+if [ -d /usr/local/obs/lib ]; then
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/obs/lib
+fi
 DATA_DIR=${FALCONFS_INSTALL_DIR}/data
 METADATA_DIR=${DATA_DIR}/metadata
 

--- a/docker/openEuler24.03-release-runtime-dockerfile
+++ b/docker/openEuler24.03-release-runtime-dockerfile
@@ -1,168 +1,59 @@
 FROM openeuler/openeuler:24.03-lts-sp2
 
-ENV LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 RUN rm -f /etc/yum.repos.d/*.repo
 COPY openEuler.repo /etc/yum.repos.d/openEuler.repo
 
+# Minimal runtime tools only. Build-time toolchains are intentionally removed.
 RUN dnf clean all && \
     dnf makecache && \
-    dnf groupinstall "Development Tools" -y && \
     dnf reinstall -y glibc-common && \
     dnf install -y \
-    pcre \
-    readline-devel gflags-devel glog-devel leveldb-devel \
-    openssl-devel postgresql-devel fuse-devel \
-    fmt-devel fio libcurl-devel jq \
-    snappy-devel gperftools-devel libunwind-devel gtest-devel gmock-devel \
-    rdma-core-devel ninja-build cmake python3-devel \
-    zstd-devel xz-devel libxml2-devel expat-devel jansson-devel \
-    systemd-devel libffi-devel \
-    autoconf automake libtool cppunit-devel \
-    protobuf-devel protobuf-compiler flatbuffers-devel flatbuffers-compiler jsoncpp-devel thrift-devel \
-    wget tar java-11-openjdk-devel maven hostname glibc-langpack-en glibc-all-langpacks \
-    python3-requests python3-psycopg2 python3-kazoo && \
+    bash \
+    coreutils \
+    curl \
+    findutils \
+    hostname \
+    jq \
+    procps-ng \
+    psmisc \
+    python3 \
+    python3-pip \
+    python3-requests \
+    python3-psycopg2 \
+    python3-kazoo \
+    shadow-utils \
+    tar \
+    util-linux \
+    wget \
+    glibc-langpack-en \
+    glibc-all-langpacks && \
     dnf clean all
 
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+# Install prebuilt third-party RPM dependencies (brpc/pg/zk, etc.) from repo local dir.
+# Put required rpms under docker/rpms before docker build.
+COPY docker/rpms/*.rpm /tmp/rpms/
+RUN set -eu; \
+    rpms=""; \
+    for f in /tmp/rpms/*.rpm; do \
+        case "$(basename "$f")" in \
+            *debuginfo*|*debugsource*) continue ;; \
+            *) rpms="${rpms} ${f}" ;; \
+        esac; \
+    done; \
+    if [ -z "${rpms}" ]; then \
+        echo "No usable RPMs found under /tmp/rpms" >&2; \
+        exit 1; \
+    fi; \
+    dnf install -y ${rpms} && \
+    dnf clean all
 
-RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
-    echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf
-
-# Fast-fail check: validate release RPM install before long source builds.
-ARG RPM_PRECHECK=1
 COPY falconfs-rpm-release.rpm /tmp/falconfs-rpm-release.rpm
-RUN if [ "${RPM_PRECHECK}" = "1" ]; then \
-        export PATH=/usr/sbin:/usr/bin:/sbin:/bin && \
-        unset LD_LIBRARY_PATH && \
-        rm -f /etc/ld.so.conf.d/obs.conf && \
-        dnf install -y /tmp/falconfs-rpm-release.rpm && \
-        dnf remove -y falconfs-release && \
-        dnf clean all; \
-    fi && \
-    rm -f /tmp/falconfs-rpm-release.rpm
 
-ARG BRPC_VERSION=1.14.1
-ARG BRPC_URL=https://github.com/apache/brpc/archive/refs/tags/${BRPC_VERSION}.tar.gz
-
-RUN wget --no-check-certificate -O- "${BRPC_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/brpc-${BRPC_VERSION}" && \
-    mkdir build && cd build && \
-    cmake -GNinja \
-          -DWITH_GLOG=ON \
-          -DWITH_RDMA=ON \
-          -DCMAKE_INSTALL_PREFIX=/usr/local \
-          -DCMAKE_PREFIX_PATH=/usr/local \
-          -DCMAKE_CXX_FLAGS="-Wno-error -Wno-deprecated-declarations" \
-          .. && \
-    ninja && \
-    ninja install && \
-    ldconfig && \
-    rm -rf "/tmp/brpc-${BRPC_VERSION}"
-
-ARG PROMETHEUS_VERSION=1.3.0
-ARG PROMETHEUS_URL=https://github.com/jupp0r/prometheus-cpp/releases/download/v${PROMETHEUS_VERSION}/prometheus-cpp-with-submodules.tar.gz
-RUN wget --no-check-certificate -O- "${PROMETHEUS_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/prometheus-cpp-with-submodules" && \
-    mkdir build && cd build && \
-    cmake .. \
-          -DBUILD_SHARED_LIBS=ON \
-          -DENABLE_PULL=ON \
-          -DENABLE_COMPRESSION=OFF \
-          -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf "/tmp/prometheus-cpp-with-submodules"
-
-ARG ZK_VERSION=3.9.1
-ARG ZK_URL=https://archive.apache.org/dist/zookeeper/zookeeper-${ZK_VERSION}/apache-zookeeper-${ZK_VERSION}.tar.gz
-ARG HTTP_PROXY_HOST=""
-ARG HTTP_PROXY_PORT=""
-ARG HTTP_PROXY_USER=""
-ARG HTTP_PROXY_PASS=""
-
-RUN wget --no-check-certificate -O- "${ZK_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/apache-zookeeper-${ZK_VERSION}" && \
-    (which hostname || (echo 'echo localhost' > /usr/bin/hostname && chmod +x /usr/bin/hostname)) && \
-    if [ -n "$HTTP_PROXY_HOST" ]; then \
-        mkdir -p ~/.m2 && \
-        printf '<?xml version="1.0" encoding="UTF-8"?>\n\
-<settings>\n\
-  <mirrors>\n\
-    <mirror>\n\
-      <id>huaweicloud</id>\n\
-      <mirrorOf>central</mirrorOf>\n\
-      <url>https://repo.huaweicloud.com/repository/maven/</url>\n\
-    </mirror>\n\
-  </mirrors>\n\
-  <proxies>\n\
-    <proxy>\n\
-      <active>true</active>\n\
-      <protocol>http</protocol>\n\
-      <host>%s</host>\n\
-      <port>%s</port>\n\
-      <username>%s</username>\n\
-      <password>%s</password>\n\
-    </proxy>\n\
-  </proxies>\n\
-</settings>' "$HTTP_PROXY_HOST" "$HTTP_PROXY_PORT" "$HTTP_PROXY_USER" "$HTTP_PROXY_PASS" > ~/.m2/settings.xml; \
-    fi && \
-    mvn compile -DskipTests -pl zookeeper-jute -T 1C && \
-    cd zookeeper-client/zookeeper-client-c && \
-    autoreconf -if && \
-    ./configure --prefix=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf ~/.m2/settings.xml "/tmp/apache-zookeeper-${ZK_VERSION}"
-
-ARG OBS_VERSION=3.24.12
-ARG SPDLOG_VERSION=1.12.0
-ARG SPDLOG_DOWNLOAD_URL=https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.tar.gz
-ARG OBS_DOWNLOAD_URL=https://github.com/huaweicloud/huaweicloud-sdk-c-obs/archive/refs/tags/v${OBS_VERSION}.tar.gz
-
-RUN wget --no-check-certificate -O- "${SPDLOG_DOWNLOAD_URL}" | tar -xzvf - -C /tmp && \
-    cd "/tmp/spdlog-${SPDLOG_VERSION}" && mkdir build && cd build && \
-    cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    make -j$(nproc) && make install && ldconfig && \
-    rm -rf "/tmp/spdlog-${SPDLOG_VERSION}"
-
-RUN wget --no-check-certificate -O- "${OBS_DOWNLOAD_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/huaweicloud-sdk-c-obs-${OBS_VERSION}/source/eSDK_OBS_API/eSDK_OBS_API_C++" && \
-    if [ "$(uname -m)" = "aarch64" ]; then PLAT="arm"; bash build_aarch.sh sdk; else PLAT="linux"; bash build.sh sdk; fi && \
-    mkdir -p /usr/local/obs && \
-    tar -zxf sdk.tgz -C /usr/local/obs && \
-    INTERNAL_SPDLOG="/tmp/huaweicloud-sdk-c-obs-${OBS_VERSION}/build/script/Provider/build/${PLAT}/spdlog-${SPDLOG_VERSION}/lib" && \
-    cp -d ${INTERNAL_SPDLOG}/libspdlog.so* /usr/local/obs/lib/ && \
-    ln -sf /usr/local/obs/lib/libiconv.so /usr/local/obs/lib/libiconv.so.0 2>/dev/null || true && \
-    rm -f /usr/local/obs/lib/libcurl.so* && \
-    ldconfig && \
-    rm -rf "/tmp/huaweicloud-sdk-c-obs-${OBS_VERSION}"
-
-# Build and install PostgreSQL from source to /usr/local/pgsql for FalconFS runtime scripts.
-ARG PG_VERSION=17.2
-ARG PG_DOWNLOAD_URL=https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.gz
-RUN wget --no-check-certificate -O- "${PG_DOWNLOAD_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/postgresql-${PG_VERSION}" && \
-    ./configure --prefix=/usr/local/pgsql --without-icu --enable-debug && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf "/tmp/postgresql-${PG_VERSION}"
-
-ENV OBS_INSTALL_PREFIX=/usr/local/obs
-ENV CPLUS_INCLUDE_PATH=${OBS_INSTALL_PREFIX}/include:/usr/local/include:${CPLUS_INCLUDE_PATH}
-ENV C_INCLUDE_PATH=${OBS_INSTALL_PREFIX}/include:/usr/local/include:${C_INCLUDE_PATH}
-ENV PATH=/usr/local/pgsql/bin:/usr/local/bin:/usr/local/sbin:${PATH}
-ENV USER=root
-
-# Install release rpm built from falconfs.source.spec
-COPY falconfs-rpm-release.rpm /tmp/falconfs-rpm-release.rpm
+# Install release rpm built from rpm/falconfs.source.spec.
 RUN export PATH=/usr/sbin:/usr/bin:/sbin:/bin && \
-    unset LD_LIBRARY_PATH && \
-    rm -f /etc/ld.so.conf.d/obs.conf && \
     dnf install -y /tmp/falconfs-rpm-release.rpm && \
     rm -f /tmp/falconfs-rpm-release.rpm && \
     dnf clean all && \

--- a/docker/rpms/README.md
+++ b/docker/rpms/README.md
@@ -1,0 +1,12 @@
+Place prebuilt dependency RPMs for openEuler release-runtime image here.
+
+Expected examples:
+- brpc-*.rpm
+- postgresql-17-*.rpm
+- postgresql-17-server-*.rpm
+- postgresql-17-private-libs-*.rpm
+- zookeeper-c-*.rpm
+
+Notes:
+- `*debuginfo*` and `*debugsource*` packages are ignored by the Dockerfile.
+- Build from repository root so `COPY docker/rpms/*.rpm /tmp/rpms/` works.

--- a/rpm/falconfs.source.spec
+++ b/rpm/falconfs.source.spec
@@ -18,6 +18,7 @@ Source0:        falconfs-%{version}.tar.gz
 # AutoReqProv:    no
 
 Requires:       bash
+Requires:       findutils
 Requires:       python3
 Requires:       python3-requests python3-psycopg2 python3-kazoo
 Requires:       postgresql-17 postgresql-17-server

--- a/tests/regress/docker-compose-release-openeuler.yaml
+++ b/tests/regress/docker-compose-release-openeuler.yaml
@@ -98,7 +98,7 @@ services:
 
   cn1:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-cn-1
     hostname: cn-1
     command: [ "bash", "/usr/local/falconfs/falcon_cn/docker-entrypoint.sh" ]
@@ -124,7 +124,7 @@ services:
 
   cn2:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-cn-2
     hostname: cn-2
     command: [ "bash", "/usr/local/falconfs/falcon_cn/docker-entrypoint.sh" ]
@@ -150,7 +150,7 @@ services:
 
   cn3:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-cn-3
     hostname: cn-3
     command: [ "bash", "/usr/local/falconfs/falcon_cn/docker-entrypoint.sh" ]
@@ -176,7 +176,7 @@ services:
 
   dn1:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-dn-1
     hostname: dn-1
     command: [ "bash", "/usr/local/falconfs/falcon_dn/docker-entrypoint.sh" ]
@@ -202,7 +202,7 @@ services:
 
   dn2:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-dn-2
     hostname: dn-2
     command: [ "bash", "/usr/local/falconfs/falcon_dn/docker-entrypoint.sh" ]
@@ -228,7 +228,7 @@ services:
 
   dn3:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-dn-3
     hostname: dn-3
     command: [ "bash", "/usr/local/falconfs/falcon_dn/docker-entrypoint.sh" ]


### PR DESCRIPTION
## Summary
- Switch openEuler release runtime image to use prebuilt dependency RPMs from `docker/rpms/`, and simplify Dockerfile flow for production usage.
- Add PostgreSQL runtime path compatibility in CN/DN startup scripts: resolve PG bin/lib via `pg_config` when available, with `/usr/local/pgsql` fallback.
- Fix CN/DN liveness checks to probe PostgreSQL via explicit TCP endpoint (`127.0.0.1:5432`) so health checks are stable across package/runtime defaults.
- Add missing runtime dependency `findutils` (Dockerfile + RPM `Requires`) to avoid `find/xargs` failures in log cleanup scripts.
- Make release compose image tag configurable via `FALCON_RELEASE_IMAGE` instead of hardcoding `v0.1.0`.
## Key Changes
- `docker/openEuler24.03-release-runtime-dockerfile`
  - Remove precheck/fast-fail build-time logic.
  - Install runtime tool `findutils`.
  - Keep direct install flow for `falconfs-rpm-release.rpm`.
- `cloud_native/docker_build/cn/start.sh`
- `cloud_native/docker_build/dn/start.sh`
  - Resolve PG runtime paths from `pg_config --bindir/--libdir` when present.
  - Keep fallback to `/usr/local/pgsql/bin` and `/usr/local/pgsql/lib`.
  - Build `LD_LIBRARY_PATH` with optional `/usr/local/obs/lib` only when directory exists.
- `cloud_native/docker_build/cn/check_liveness.sh`
- `cloud_native/docker_build/dn/check_liveness.sh`
  - Use: `pg_isready -h 127.0.0.1 -p 5432 ...`
- `rpm/falconfs.source.spec`
  - Add `Requires: findutils`.
- `tests/regress/docker-compose-release-openeuler.yaml`
  - Replace hardcoded image with:
    - `${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}`
- `docker/rpms/README.md`
  - Document placement and expected dependency RPMs for openEuler runtime build.
## Validation
- Built `falconfs-release` RPM on openEuler.
- Built release runtime image from updated Dockerfile.
- Verified compose startup flow with configurable release image tag.
- Verified CN/DN health checks pass with explicit TCP probe against PostgreSQL.
liuwei@localhost:~/code/falconfs$ docker-compose -f tests/regress/docker-compose-release-openeuler.yaml exec cn1 sh -lc 'pg_isready -h /tmp -p 5432 -U falconMeta -d postgres || true'
WARN[0000] /home/liuwei/code/falconfs/tests/regress/docker-compose-release-openeuler.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
/tmp:5432 - accepting connections
liuwei@localhost:~/code/falconfs$ docker-compose -f tests/regress/docker-compose-release-openeuler.yaml exec cn1 sh -lc 'pg_isready  /tmp -p 5432 -U falconMeta -d postgres || true'
WARN[0000] /home/liuwei/code/falconfs/tests/regress/docker-compose-release-openeuler.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
pg_isready: error: too many command-line arguments (first is "/tmp")
pg_isready: hint: Try "pg_isready --help" for more information.
docker-compose -f tests/regress/docker-compose-release-openeuler.yaml ps
WARN[0000] /home/liuwei/code/falconfs/tests/regress/docker-compose-release-openeuler.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
NAME          IMAGE                                    COMMAND                   SERVICE   CREATED      STATUS                PORTS
falcon-cn-1   falconfs-release-openeuler24.03:v0.5.0   "bash /usr/local/fal…"   cn1       2 days ago   Up 2 days (healthy)   
falcon-cn-2   falconfs-release-openeuler24.03:v0.5.0   "bash /usr/local/fal…"   cn2       2 days ago   Up 2 days (healthy)   
falcon-cn-3   falconfs-release-openeuler24.03:v0.5.0   "bash /usr/local/fal…"   cn3       2 days ago   Up 2 days (healthy)   
falcon-dn-1   falconfs-release-openeuler24.03:v0.5.0   "bash /usr/local/fal…"   dn1       2 days ago   Up 2 days (healthy)   
falcon-dn-2   falconfs-release-openeuler24.03:v0.5.0   "bash /usr/local/fal…"   dn2       2 days ago   Up 2 days (healthy)   
falcon-dn-3   falconfs-release-openeuler24.03:v0.5.0   "bash /usr/local/fal…"   dn3       2 days ago   Up 2 days (healthy)   
falcon-zk-1   zookeeper:3.8.3                          "/docker-entrypoint.…"   zk1       2 days ago   Up 2 days (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp
falcon-zk-2   zookeeper:3.8.3                          "/docker-entrypoint.…"   zk2       2 days ago   Up 2 days (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp
falcon-zk-3   zookeeper:3.8.3                          "/docker-entrypoint.…"   zk3       2 days ago   Up 2 days (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp
