### PR TITLE
refactor: decouple hcom plugin from falcon.so linkage

### DIFF
--- a/falcon/MakefilePlugin.hcom
+++ b/falcon/MakefilePlugin.hcom
@@ -18,7 +18,7 @@ HCOM_PLUGIN_CPPFLAGS = -I./include -I./connection_pool/fbs \
 			  -I$(REMOTE_CONNECTION_DEF_DIR) \
 			  -I/usr/local/include
 
-HCOM_PLUGIN_LINK_LIB = -L. -l:falcon.so -lpthread -ldl
+HCOM_PLUGIN_LINK_LIB = -lpthread -ldl
 
 HCOM_PLUGIN_LIB_NAME = libhcomplugin.so
 

--- a/falcon/hcom_comm_adapter/falcon_meta_service.cpp
+++ b/falcon/hcom_comm_adapter/falcon_meta_service.cpp
@@ -23,7 +23,6 @@
 #include "hcom_comm_adapter/falcon_meta_service_internal.h"
 #include "hcom_comm_adapter/falcon_meta_service_job.h"
 #include "plugin/falcon_plugin_framework.h"
-#include "utils/falcon_plugin_guc.h"
 
 extern "C" {
 #include "remote_connection_utils/serialized_data.h"
@@ -33,6 +32,24 @@ namespace falcon
 {
 namespace meta_service
 {
+
+static const char *ResolvePluginDirectory()
+{
+    const char *env_plugin_dir = std::getenv("FALCON_PLUGIN_DIRECTORY");
+    if (env_plugin_dir != nullptr && env_plugin_dir[0] != '\0') {
+        return env_plugin_dir;
+    }
+
+    void *symbol = dlsym(RTLD_DEFAULT, "falcon_plugin_directory");
+    if (symbol != nullptr) {
+        char **guc_plugin_dir = reinterpret_cast<char **>(symbol);
+        if (guc_plugin_dir != nullptr && *guc_plugin_dir != nullptr && (*guc_plugin_dir)[0] != '\0') {
+            return *guc_plugin_dir;
+        }
+    }
+
+    return nullptr;
+}
 
 static falcon_meta_job_dispatch_func g_dispatchFunc = nullptr;
 FalconMetaService *FalconMetaService::instance = nullptr;
@@ -880,14 +897,16 @@ class FalconHcomServer {
     bool LoadPlugins()
     {
         fprintf(stderr, "[Log] [FalconHcomServer] In LoadPlugins\n"); 
-        if (falcon_plugin_directory == nullptr || falcon_plugin_directory[0] == '\0') {
-            fprintf(stderr, "[WARNING] [FalconHcomServer] falcon_plugin_directory not set\n");
+        const char *plugin_dir = ResolvePluginDirectory();
+        if (plugin_dir == nullptr) {
+            fprintf(stderr,
+                    "[WARNING] [FalconHcomServer] plugin directory not set (env FALCON_PLUGIN_DIRECTORY and symbol falcon_plugin_directory are empty)\n");
             return false;
         }
 
-        DIR *dir = opendir(falcon_plugin_directory);
+        DIR *dir = opendir(plugin_dir);
         if (!dir) {
-            fprintf(stderr, "[WARNING] [FalconHcomServer] Cannot open plugin directory: %s\n", falcon_plugin_directory);
+            fprintf(stderr, "[WARNING] [FalconHcomServer] Cannot open plugin directory: %s\n", plugin_dir);
             return false;
         }
 
@@ -899,7 +918,7 @@ class FalconHcomServer {
             }
 
             char plugin_path[FALCON_PLUGIN_MAX_PATH_SIZE];
-            snprintf(plugin_path, sizeof(plugin_path), "%s/%s", falcon_plugin_directory, entry->d_name);
+            snprintf(plugin_path, sizeof(plugin_path), "%s/%s", plugin_dir, entry->d_name);
 
             void *dl_handle = dlopen(plugin_path, RTLD_LAZY);
             if (!dl_handle) {


### PR DESCRIPTION
## Summary
- Remove hard link-time dependency from `libhcomplugin.so` to `falcon.so` by dropping `-l:falcon.so` in `falcon/MakefilePlugin.hcom`.
- Replace direct compile-time use of `falcon_plugin_directory` with runtime resolution in `falcon/hcom_comm_adapter/falcon_meta_service.cpp`.
- Plugin directory resolution now supports:
  - `FALCON_PLUGIN_DIRECTORY` environment variable (preferred if set)
  - fallback to runtime symbol lookup via `dlsym(RTLD_DEFAULT, "falcon_plugin_directory")`
## Why
- In RPM/release runtime environments, `falcon.so` may not be resolvable as a hard dependency for `libhcomplugin.so`, causing hcom startup failures.
- This change converts the dependency to runtime-optional lookup, improving portability and startup robustness.
## Verification
- Built with `./build.sh build falcon --comm-plugin=hcom`.
2026-04-13 20:17:17.710 CST [1807213] LOG:  FalconDaemon2PCFailureCleanupProcessMain: init finished.
2026-04-13 20:17:17.710 CST [1807213] LOG:  FalconDaemon2PCFailureCleanupProcessMain: Running.
2026-04-13 20:17:17.811 CST [1807212] LOG:  Using plugin /usr/local/falconfs/falcon_meta/lib/postgresql/libhcomplugin.so start CommunicationSever.
[LOG] [FalconHcomServer] In StartFalconCommunicationServer
[Log] [FalconHcomServer] In LoadPlugins
[LOG] [FalconHcomServer] Loading plugin: /home/liuwei/code/falconfs/plugins/libfalcon_meta_service_test_plugin.so
[FalconMetaServiceTestPlugin] plugin_init() called
[FalconMetaServiceTestPlugin] plugin_init() completed
[FalconMetaServiceTestPlugin] plugin_work() called
[FalconMetaServiceTestPlugin] FalconMetaService instance ready

- Confirmed `libhcomplugin.so` no longer has `NEEDED: falcon.so`.
liuwei@localhost:~/code/falconfs$ ldd /usr/local/falconfs/falcon_meta/lib/postgresql/libhcomplugin.so
	linux-vdso.so.1 (0x00007ffddc308000)
	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007f235e200000)
	libm.so.6 => /usr/lib64/libm.so.6 (0x00007f235e123000)
	libgcc_s.so.1 => /usr/lib64/libgcc_s.so.1 (0x00007f235e103000)
	libc.so.6 => /usr/lib64/libc.so.6 (0x00007f235df2b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f235e474000)