### PR TITLE
Feat/rpm dual plugin support

### DIFF
--- a/cloud_native/docker_build/cn/check_liveness.sh
+++ b/cloud_native/docker_build/cn/check_liveness.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pg_isready -d postgres -U falconMeta --timeout=5 --quiet
+pg_isready -h 127.0.0.1 -p 5432 -d postgres -U falconMeta --timeout=5 --quiet
 if [ $? != 0 ]; then
     exit 1;
 fi

--- a/cloud_native/docker_build/cn/start.sh
+++ b/cloud_native/docker_build/cn/start.sh
@@ -2,6 +2,12 @@
 # 使用源码编译安装的 PostgreSQL 17
 # 设置默认的安装目录
 FALCONFS_INSTALL_DIR=${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}
+COMM_PLUGIN=${FALCON_COMM_PLUGIN:-brpc}
+
+if [[ "${COMM_PLUGIN}" != "brpc" && "${COMM_PLUGIN}" != "hcom" ]]; then
+    echo "ERROR: Unsupported FALCON_COMM_PLUGIN='${COMM_PLUGIN}' (use brpc or hcom)" >&2
+    exit 1
+fi
 
 PG_BIN_DIR=${FALCON_PG_BIN_DIR:-}
 PG_LIB_DIR=${FALCON_PG_LIB_DIR:-}
@@ -22,6 +28,12 @@ if [ -d /usr/local/obs/lib ]; then
 fi
 DATA_DIR=${FALCONFS_INSTALL_DIR}/data
 METADATA_DIR=${DATA_DIR}/metadata
+COMM_PLUGIN_PATH="${FALCONFS_INSTALL_DIR}/falcon_meta/lib/postgresql/lib${COMM_PLUGIN}plugin.so"
+
+if [ ! -f "${COMM_PLUGIN_PATH}" ]; then
+    echo "ERROR: communication plugin not found: ${COMM_PLUGIN_PATH}" >&2
+    exit 1
+fi
 
 if [ -d "${METADATA_DIR}/pg_wal" ]; then
     pg_ctl restart -D ${METADATA_DIR}
@@ -64,7 +76,7 @@ else
     echo "falcon_connection_pool.wait_adjust = 1" >>${METADATA_DIR}/postgresql.conf
     echo "falcon_connection_pool.wait_min = 1" >>${METADATA_DIR}/postgresql.conf
     echo "falcon_connection_pool.wait_max = 500" >>${METADATA_DIR}/postgresql.conf
-    echo "falcon_communication.plugin_path = '${FALCONFS_INSTALL_DIR}/falcon_meta/lib/postgresql/libbrpcplugin.so'" >>${METADATA_DIR}/postgresql.conf
+    echo "falcon_communication.plugin_path = '${COMM_PLUGIN_PATH}'" >>${METADATA_DIR}/postgresql.conf
     echo "falcon_communication.server_ip = '${POD_IP}'" >>${METADATA_DIR}/postgresql.conf
     pg_ctl start -D ${METADATA_DIR}
 fi

--- a/cloud_native/docker_build/cn/start.sh
+++ b/cloud_native/docker_build/cn/start.sh
@@ -3,8 +3,23 @@
 # 设置默认的安装目录
 FALCONFS_INSTALL_DIR=${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}
 
-export PATH=/usr/local/pgsql/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/pgsql/lib:${FALCONFS_INSTALL_DIR}/falcon_meta/lib:/usr/local/obs/lib
+PG_BIN_DIR=${FALCON_PG_BIN_DIR:-}
+PG_LIB_DIR=${FALCON_PG_LIB_DIR:-}
+if [ -z "${PG_BIN_DIR}" ] || [ -z "${PG_LIB_DIR}" ]; then
+    if command -v pg_config >/dev/null 2>&1; then
+        [ -z "${PG_BIN_DIR}" ] && PG_BIN_DIR="$(pg_config --bindir)"
+        [ -z "${PG_LIB_DIR}" ] && PG_LIB_DIR="$(pg_config --libdir)"
+    fi
+fi
+
+PG_BIN_DIR=${PG_BIN_DIR:-/usr/local/pgsql/bin}
+PG_LIB_DIR=${PG_LIB_DIR:-/usr/local/pgsql/lib}
+
+export PATH=${PG_BIN_DIR}:$PATH
+export LD_LIBRARY_PATH=${PG_LIB_DIR}:${FALCONFS_INSTALL_DIR}/falcon_meta/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+if [ -d /usr/local/obs/lib ]; then
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/obs/lib
+fi
 DATA_DIR=${FALCONFS_INSTALL_DIR}/data
 METADATA_DIR=${DATA_DIR}/metadata
 

--- a/cloud_native/docker_build/dn/check_liveness.sh
+++ b/cloud_native/docker_build/dn/check_liveness.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pg_isready -d postgres -U falconMeta --timeout=5 --quiet
+pg_isready -h 127.0.0.1 -p 5432 -d postgres -U falconMeta --timeout=5 --quiet
 if [ $? != 0 ]; then
     exit 1;
 fi

--- a/cloud_native/docker_build/dn/start.sh
+++ b/cloud_native/docker_build/dn/start.sh
@@ -2,6 +2,12 @@
 # 使用源码编译安装的 PostgreSQL 17
 # 设置默认的安装目录
 FALCONFS_INSTALL_DIR=${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}
+COMM_PLUGIN=${FALCON_COMM_PLUGIN:-brpc}
+
+if [[ "${COMM_PLUGIN}" != "brpc" && "${COMM_PLUGIN}" != "hcom" ]]; then
+    echo "ERROR: Unsupported FALCON_COMM_PLUGIN='${COMM_PLUGIN}' (use brpc or hcom)" >&2
+    exit 1
+fi
 
 PG_BIN_DIR=${FALCON_PG_BIN_DIR:-}
 PG_LIB_DIR=${FALCON_PG_LIB_DIR:-}
@@ -22,6 +28,12 @@ if [ -d /usr/local/obs/lib ]; then
 fi
 DATA_DIR=${FALCONFS_INSTALL_DIR}/data
 METADATA_DIR=${DATA_DIR}/metadata
+COMM_PLUGIN_PATH="${FALCONFS_INSTALL_DIR}/falcon_meta/lib/postgresql/lib${COMM_PLUGIN}plugin.so"
+
+if [ ! -f "${COMM_PLUGIN_PATH}" ]; then
+    echo "ERROR: communication plugin not found: ${COMM_PLUGIN_PATH}" >&2
+    exit 1
+fi
 
 if [ -d "${METADATA_DIR}/pg_wal" ]; then
     pg_ctl restart -D ${METADATA_DIR}
@@ -62,7 +74,7 @@ else
     echo "falcon_connection_pool.wait_adjust = 1" >>${METADATA_DIR}/postgresql.conf
     echo "falcon_connection_pool.wait_min = 1" >>${METADATA_DIR}/postgresql.conf
     echo "falcon_connection_pool.wait_max = 500" >>${METADATA_DIR}/postgresql.conf
-    echo "falcon_communication.plugin_path = '${FALCONFS_INSTALL_DIR}/falcon_meta/lib/postgresql/libbrpcplugin.so'" >>${METADATA_DIR}/postgresql.conf
+    echo "falcon_communication.plugin_path = '${COMM_PLUGIN_PATH}'" >>${METADATA_DIR}/postgresql.conf
     echo "falcon_communication.server_ip = '${POD_IP:-127.0.0.1}'" >>${METADATA_DIR}/postgresql.conf
     pg_ctl start -D ${METADATA_DIR}
 fi

--- a/cloud_native/docker_build/dn/start.sh
+++ b/cloud_native/docker_build/dn/start.sh
@@ -3,8 +3,23 @@
 # 设置默认的安装目录
 FALCONFS_INSTALL_DIR=${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}
 
-export PATH=/usr/local/pgsql/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/pgsql/lib:${FALCONFS_INSTALL_DIR}/falcon_meta/lib:/usr/local/obs/lib
+PG_BIN_DIR=${FALCON_PG_BIN_DIR:-}
+PG_LIB_DIR=${FALCON_PG_LIB_DIR:-}
+if [ -z "${PG_BIN_DIR}" ] || [ -z "${PG_LIB_DIR}" ]; then
+    if command -v pg_config >/dev/null 2>&1; then
+        [ -z "${PG_BIN_DIR}" ] && PG_BIN_DIR="$(pg_config --bindir)"
+        [ -z "${PG_LIB_DIR}" ] && PG_LIB_DIR="$(pg_config --libdir)"
+    fi
+fi
+
+PG_BIN_DIR=${PG_BIN_DIR:-/usr/local/pgsql/bin}
+PG_LIB_DIR=${PG_LIB_DIR:-/usr/local/pgsql/lib}
+
+export PATH=${PG_BIN_DIR}:$PATH
+export LD_LIBRARY_PATH=${PG_LIB_DIR}:${FALCONFS_INSTALL_DIR}/falcon_meta/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+if [ -d /usr/local/obs/lib ]; then
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/obs/lib
+fi
 DATA_DIR=${FALCONFS_INSTALL_DIR}/data
 METADATA_DIR=${DATA_DIR}/metadata
 

--- a/docker/openEuler24.03-release-runtime-dockerfile
+++ b/docker/openEuler24.03-release-runtime-dockerfile
@@ -1,168 +1,59 @@
 FROM openeuler/openeuler:24.03-lts-sp2
 
-ENV LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 RUN rm -f /etc/yum.repos.d/*.repo
 COPY openEuler.repo /etc/yum.repos.d/openEuler.repo
 
+# Minimal runtime tools only. Build-time toolchains are intentionally removed.
 RUN dnf clean all && \
     dnf makecache && \
-    dnf groupinstall "Development Tools" -y && \
     dnf reinstall -y glibc-common && \
     dnf install -y \
-    pcre \
-    readline-devel gflags-devel glog-devel leveldb-devel \
-    openssl-devel postgresql-devel fuse-devel \
-    fmt-devel fio libcurl-devel jq \
-    snappy-devel gperftools-devel libunwind-devel gtest-devel gmock-devel \
-    rdma-core-devel ninja-build cmake python3-devel \
-    zstd-devel xz-devel libxml2-devel expat-devel jansson-devel \
-    systemd-devel libffi-devel \
-    autoconf automake libtool cppunit-devel \
-    protobuf-devel protobuf-compiler flatbuffers-devel flatbuffers-compiler jsoncpp-devel thrift-devel \
-    wget tar java-11-openjdk-devel maven hostname glibc-langpack-en glibc-all-langpacks \
-    python3-requests python3-psycopg2 python3-kazoo && \
+    bash \
+    coreutils \
+    curl \
+    findutils \
+    hostname \
+    jq \
+    procps-ng \
+    psmisc \
+    python3 \
+    python3-pip \
+    python3-requests \
+    python3-psycopg2 \
+    python3-kazoo \
+    shadow-utils \
+    tar \
+    util-linux \
+    wget \
+    glibc-langpack-en \
+    glibc-all-langpacks && \
     dnf clean all
 
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+# Install prebuilt third-party RPM dependencies (brpc/pg/zk, etc.) from repo local dir.
+# Put required rpms under docker/rpms before docker build.
+COPY docker/rpms/*.rpm /tmp/rpms/
+RUN set -eu; \
+    rpms=""; \
+    for f in /tmp/rpms/*.rpm; do \
+        case "$(basename "$f")" in \
+            *debuginfo*|*debugsource*) continue ;; \
+            *) rpms="${rpms} ${f}" ;; \
+        esac; \
+    done; \
+    if [ -z "${rpms}" ]; then \
+        echo "No usable RPMs found under /tmp/rpms" >&2; \
+        exit 1; \
+    fi; \
+    dnf install -y ${rpms} && \
+    dnf clean all
 
-RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
-    echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf
-
-# Fast-fail check: validate release RPM install before long source builds.
-ARG RPM_PRECHECK=1
 COPY falconfs-rpm-release.rpm /tmp/falconfs-rpm-release.rpm
-RUN if [ "${RPM_PRECHECK}" = "1" ]; then \
-        export PATH=/usr/sbin:/usr/bin:/sbin:/bin && \
-        unset LD_LIBRARY_PATH && \
-        rm -f /etc/ld.so.conf.d/obs.conf && \
-        dnf install -y /tmp/falconfs-rpm-release.rpm && \
-        dnf remove -y falconfs-release && \
-        dnf clean all; \
-    fi && \
-    rm -f /tmp/falconfs-rpm-release.rpm
 
-ARG BRPC_VERSION=1.14.1
-ARG BRPC_URL=https://github.com/apache/brpc/archive/refs/tags/${BRPC_VERSION}.tar.gz
-
-RUN wget --no-check-certificate -O- "${BRPC_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/brpc-${BRPC_VERSION}" && \
-    mkdir build && cd build && \
-    cmake -GNinja \
-          -DWITH_GLOG=ON \
-          -DWITH_RDMA=ON \
-          -DCMAKE_INSTALL_PREFIX=/usr/local \
-          -DCMAKE_PREFIX_PATH=/usr/local \
-          -DCMAKE_CXX_FLAGS="-Wno-error -Wno-deprecated-declarations" \
-          .. && \
-    ninja && \
-    ninja install && \
-    ldconfig && \
-    rm -rf "/tmp/brpc-${BRPC_VERSION}"
-
-ARG PROMETHEUS_VERSION=1.3.0
-ARG PROMETHEUS_URL=https://github.com/jupp0r/prometheus-cpp/releases/download/v${PROMETHEUS_VERSION}/prometheus-cpp-with-submodules.tar.gz
-RUN wget --no-check-certificate -O- "${PROMETHEUS_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/prometheus-cpp-with-submodules" && \
-    mkdir build && cd build && \
-    cmake .. \
-          -DBUILD_SHARED_LIBS=ON \
-          -DENABLE_PULL=ON \
-          -DENABLE_COMPRESSION=OFF \
-          -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf "/tmp/prometheus-cpp-with-submodules"
-
-ARG ZK_VERSION=3.9.1
-ARG ZK_URL=https://archive.apache.org/dist/zookeeper/zookeeper-${ZK_VERSION}/apache-zookeeper-${ZK_VERSION}.tar.gz
-ARG HTTP_PROXY_HOST=""
-ARG HTTP_PROXY_PORT=""
-ARG HTTP_PROXY_USER=""
-ARG HTTP_PROXY_PASS=""
-
-RUN wget --no-check-certificate -O- "${ZK_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/apache-zookeeper-${ZK_VERSION}" && \
-    (which hostname || (echo 'echo localhost' > /usr/bin/hostname && chmod +x /usr/bin/hostname)) && \
-    if [ -n "$HTTP_PROXY_HOST" ]; then \
-        mkdir -p ~/.m2 && \
-        printf '<?xml version="1.0" encoding="UTF-8"?>\n\
-<settings>\n\
-  <mirrors>\n\
-    <mirror>\n\
-      <id>huaweicloud</id>\n\
-      <mirrorOf>central</mirrorOf>\n\
-      <url>https://repo.huaweicloud.com/repository/maven/</url>\n\
-    </mirror>\n\
-  </mirrors>\n\
-  <proxies>\n\
-    <proxy>\n\
-      <active>true</active>\n\
-      <protocol>http</protocol>\n\
-      <host>%s</host>\n\
-      <port>%s</port>\n\
-      <username>%s</username>\n\
-      <password>%s</password>\n\
-    </proxy>\n\
-  </proxies>\n\
-</settings>' "$HTTP_PROXY_HOST" "$HTTP_PROXY_PORT" "$HTTP_PROXY_USER" "$HTTP_PROXY_PASS" > ~/.m2/settings.xml; \
-    fi && \
-    mvn compile -DskipTests -pl zookeeper-jute -T 1C && \
-    cd zookeeper-client/zookeeper-client-c && \
-    autoreconf -if && \
-    ./configure --prefix=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf ~/.m2/settings.xml "/tmp/apache-zookeeper-${ZK_VERSION}"
-
-ARG OBS_VERSION=3.24.12
-ARG SPDLOG_VERSION=1.12.0
-ARG SPDLOG_DOWNLOAD_URL=https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.tar.gz
-ARG OBS_DOWNLOAD_URL=https://github.com/huaweicloud/huaweicloud-sdk-c-obs/archive/refs/tags/v${OBS_VERSION}.tar.gz
-
-RUN wget --no-check-certificate -O- "${SPDLOG_DOWNLOAD_URL}" | tar -xzvf - -C /tmp && \
-    cd "/tmp/spdlog-${SPDLOG_VERSION}" && mkdir build && cd build && \
-    cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    make -j$(nproc) && make install && ldconfig && \
-    rm -rf "/tmp/spdlog-${SPDLOG_VERSION}"
-
-RUN wget --no-check-certificate -O- "${OBS_DOWNLOAD_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/huaweicloud-sdk-c-obs-${OBS_VERSION}/source/eSDK_OBS_API/eSDK_OBS_API_C++" && \
-    if [ "$(uname -m)" = "aarch64" ]; then PLAT="arm"; bash build_aarch.sh sdk; else PLAT="linux"; bash build.sh sdk; fi && \
-    mkdir -p /usr/local/obs && \
-    tar -zxf sdk.tgz -C /usr/local/obs && \
-    INTERNAL_SPDLOG="/tmp/huaweicloud-sdk-c-obs-${OBS_VERSION}/build/script/Provider/build/${PLAT}/spdlog-${SPDLOG_VERSION}/lib" && \
-    cp -d ${INTERNAL_SPDLOG}/libspdlog.so* /usr/local/obs/lib/ && \
-    ln -sf /usr/local/obs/lib/libiconv.so /usr/local/obs/lib/libiconv.so.0 2>/dev/null || true && \
-    rm -f /usr/local/obs/lib/libcurl.so* && \
-    ldconfig && \
-    rm -rf "/tmp/huaweicloud-sdk-c-obs-${OBS_VERSION}"
-
-# Build and install PostgreSQL from source to /usr/local/pgsql for FalconFS runtime scripts.
-ARG PG_VERSION=17.2
-ARG PG_DOWNLOAD_URL=https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.gz
-RUN wget --no-check-certificate -O- "${PG_DOWNLOAD_URL}" | tar -xz -C /tmp && \
-    cd "/tmp/postgresql-${PG_VERSION}" && \
-    ./configure --prefix=/usr/local/pgsql --without-icu --enable-debug && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf "/tmp/postgresql-${PG_VERSION}"
-
-ENV OBS_INSTALL_PREFIX=/usr/local/obs
-ENV CPLUS_INCLUDE_PATH=${OBS_INSTALL_PREFIX}/include:/usr/local/include:${CPLUS_INCLUDE_PATH}
-ENV C_INCLUDE_PATH=${OBS_INSTALL_PREFIX}/include:/usr/local/include:${C_INCLUDE_PATH}
-ENV PATH=/usr/local/pgsql/bin:/usr/local/bin:/usr/local/sbin:${PATH}
-ENV USER=root
-
-# Install release rpm built from falconfs.source.spec
-COPY falconfs-rpm-release.rpm /tmp/falconfs-rpm-release.rpm
+# Install release rpm built from rpm/falconfs.source.spec.
 RUN export PATH=/usr/sbin:/usr/bin:/sbin:/bin && \
-    unset LD_LIBRARY_PATH && \
-    rm -f /etc/ld.so.conf.d/obs.conf && \
     dnf install -y /tmp/falconfs-rpm-release.rpm && \
     rm -f /tmp/falconfs-rpm-release.rpm && \
     dnf clean all && \

--- a/docker/rpms/README.md
+++ b/docker/rpms/README.md
@@ -1,0 +1,12 @@
+Place prebuilt dependency RPMs for openEuler release-runtime image here.
+
+Expected examples:
+- brpc-*.rpm
+- postgresql-17-*.rpm
+- postgresql-17-server-*.rpm
+- postgresql-17-private-libs-*.rpm
+- zookeeper-c-*.rpm
+
+Notes:
+- `*debuginfo*` and `*debugsource*` packages are ignored by the Dockerfile.
+- Build from repository root so `COPY docker/rpms/*.rpm /tmp/rpms/` works.

--- a/falcon/MakefilePlugin.hcom
+++ b/falcon/MakefilePlugin.hcom
@@ -18,7 +18,7 @@ HCOM_PLUGIN_CPPFLAGS = -I./include -I./connection_pool/fbs \
 			  -I$(REMOTE_CONNECTION_DEF_DIR) \
 			  -I/usr/local/include
 
-HCOM_PLUGIN_LINK_LIB = -L. -l:falcon.so -lpthread -ldl
+HCOM_PLUGIN_LINK_LIB = -lpthread -ldl
 
 HCOM_PLUGIN_LIB_NAME = libhcomplugin.so
 

--- a/falcon/hcom_comm_adapter/falcon_meta_service.cpp
+++ b/falcon/hcom_comm_adapter/falcon_meta_service.cpp
@@ -23,7 +23,6 @@
 #include "hcom_comm_adapter/falcon_meta_service_internal.h"
 #include "hcom_comm_adapter/falcon_meta_service_job.h"
 #include "plugin/falcon_plugin_framework.h"
-#include "utils/falcon_plugin_guc.h"
 
 extern "C" {
 #include "remote_connection_utils/serialized_data.h"
@@ -33,6 +32,24 @@ namespace falcon
 {
 namespace meta_service
 {
+
+static const char *ResolvePluginDirectory()
+{
+    const char *env_plugin_dir = std::getenv("FALCON_PLUGIN_DIRECTORY");
+    if (env_plugin_dir != nullptr && env_plugin_dir[0] != '\0') {
+        return env_plugin_dir;
+    }
+
+    void *symbol = dlsym(RTLD_DEFAULT, "falcon_plugin_directory");
+    if (symbol != nullptr) {
+        char **guc_plugin_dir = reinterpret_cast<char **>(symbol);
+        if (guc_plugin_dir != nullptr && *guc_plugin_dir != nullptr && (*guc_plugin_dir)[0] != '\0') {
+            return *guc_plugin_dir;
+        }
+    }
+
+    return nullptr;
+}
 
 static falcon_meta_job_dispatch_func g_dispatchFunc = nullptr;
 FalconMetaService *FalconMetaService::instance = nullptr;
@@ -880,14 +897,16 @@ class FalconHcomServer {
     bool LoadPlugins()
     {
         fprintf(stderr, "[Log] [FalconHcomServer] In LoadPlugins\n"); 
-        if (falcon_plugin_directory == nullptr || falcon_plugin_directory[0] == '\0') {
-            fprintf(stderr, "[WARNING] [FalconHcomServer] falcon_plugin_directory not set\n");
+        const char *plugin_dir = ResolvePluginDirectory();
+        if (plugin_dir == nullptr) {
+            fprintf(stderr,
+                    "[WARNING] [FalconHcomServer] plugin directory not set (env FALCON_PLUGIN_DIRECTORY and symbol falcon_plugin_directory are empty)\n");
             return false;
         }
 
-        DIR *dir = opendir(falcon_plugin_directory);
+        DIR *dir = opendir(plugin_dir);
         if (!dir) {
-            fprintf(stderr, "[WARNING] [FalconHcomServer] Cannot open plugin directory: %s\n", falcon_plugin_directory);
+            fprintf(stderr, "[WARNING] [FalconHcomServer] Cannot open plugin directory: %s\n", plugin_dir);
             return false;
         }
 
@@ -899,7 +918,7 @@ class FalconHcomServer {
             }
 
             char plugin_path[FALCON_PLUGIN_MAX_PATH_SIZE];
-            snprintf(plugin_path, sizeof(plugin_path), "%s/%s", falcon_plugin_directory, entry->d_name);
+            snprintf(plugin_path, sizeof(plugin_path), "%s/%s", plugin_dir, entry->d_name);
 
             void *dl_handle = dlopen(plugin_path, RTLD_LAZY);
             if (!dl_handle) {

--- a/rpm/README.source.md
+++ b/rpm/README.source.md
@@ -138,6 +138,18 @@ sudo chown -R "$USER":"$USER" /usr/local/falconfs
 
 - release 包用于容器部署
   - 建议配合 `tests/regress/docker-compose-release-openeuler.yaml` 做集群启动验证。
+  - 通信插件可通过环境变量切换（默认 `brpc`）：
+
+```bash
+export FALCON_COMM_PLUGIN=hcom
+docker compose -f tests/regress/docker-compose-release-openeuler.yaml up -d
+```
+
+  - 校验容器内生效配置：
+
+```bash
+docker exec falcon-cn-1 grep falcon_communication.plugin_path /usr/local/falconfs/data/metadata/postgresql.conf
+```
 
 - ZooKeeper 集群编号
   - 若手工部署 ZK 集群，`myid` 建议从 `1` 开始（与 compose 中 `zk1/zk2/...` 约定一致）。

--- a/rpm/falconfs.source.spec
+++ b/rpm/falconfs.source.spec
@@ -76,7 +76,11 @@ export FALCONFS_INSTALL_DIR="${STAGE_ROOT}/usr/local/falconfs"
 mkdir -p "${STAGE_ROOT}"
 echo "Using pg_config: $(command -v pg_config)"
 pg_config --pgxs
-./build.sh build falcon
+./build.sh build falcon --comm-plugin=brpc
+./build.sh build falcon --comm-plugin=hcom
+
+test -f ./falcon/libbrpcplugin.so
+test -f ./falcon/libhcomplugin.so
 
 %install
 set -euo pipefail
@@ -84,7 +88,14 @@ export STAGE_ROOT="%{_builddir}/falconfs-stage"
 export FALCONFS_INSTALL_DIR="${STAGE_ROOT}/usr/local/falconfs"
 rm -rf "%{buildroot}" "${STAGE_ROOT}"
 mkdir -p "${STAGE_ROOT}"
-./build.sh install falcon
+./build.sh install falcon --comm-plugin=brpc
+
+# Keep both communication plugins in RPM so runtime can switch via config.
+install -m 0755 -D ./falcon/libhcomplugin.so \
+    "${STAGE_ROOT}/usr/local/falconfs/falcon_meta/lib/postgresql/libhcomplugin.so"
+
+test -f "${STAGE_ROOT}/usr/local/falconfs/falcon_meta/lib/postgresql/libbrpcplugin.so"
+test -f "${STAGE_ROOT}/usr/local/falconfs/falcon_meta/lib/postgresql/libhcomplugin.so"
 mkdir -p "%{buildroot}"
 cp -a "${STAGE_ROOT}/"* "%{buildroot}/"
 %if 0%{?release_pkg}

--- a/rpm/falconfs.source.spec
+++ b/rpm/falconfs.source.spec
@@ -18,6 +18,7 @@ Source0:        falconfs-%{version}.tar.gz
 # AutoReqProv:    no
 
 Requires:       bash
+Requires:       findutils
 Requires:       python3
 Requires:       python3-requests python3-psycopg2 python3-kazoo
 Requires:       postgresql-17 postgresql-17-server

--- a/tests/regress/docker-compose-release-openeuler.yaml
+++ b/tests/regress/docker-compose-release-openeuler.yaml
@@ -2,6 +2,7 @@ version: "3.8"
 
 x-falcon-env: &falcon-env
   POD_NAMESPACE: falconfs
+  FALCON_COMM_PLUGIN: ${FALCON_COMM_PLUGIN:-brpc}
   zk_endpoint: zk-1:2181,zk-2:2181,zk-3:2181
   cluster_name: "/falcon"
   STORAGE_THRESHOLD: "0.9"

--- a/tests/regress/docker-compose-release-openeuler.yaml
+++ b/tests/regress/docker-compose-release-openeuler.yaml
@@ -98,7 +98,7 @@ services:
 
   cn1:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-cn-1
     hostname: cn-1
     command: [ "bash", "/usr/local/falconfs/falcon_cn/docker-entrypoint.sh" ]
@@ -124,7 +124,7 @@ services:
 
   cn2:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-cn-2
     hostname: cn-2
     command: [ "bash", "/usr/local/falconfs/falcon_cn/docker-entrypoint.sh" ]
@@ -150,7 +150,7 @@ services:
 
   cn3:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-cn-3
     hostname: cn-3
     command: [ "bash", "/usr/local/falconfs/falcon_cn/docker-entrypoint.sh" ]
@@ -176,7 +176,7 @@ services:
 
   dn1:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-dn-1
     hostname: dn-1
     command: [ "bash", "/usr/local/falconfs/falcon_dn/docker-entrypoint.sh" ]
@@ -202,7 +202,7 @@ services:
 
   dn2:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-dn-2
     hostname: dn-2
     command: [ "bash", "/usr/local/falconfs/falcon_dn/docker-entrypoint.sh" ]
@@ -228,7 +228,7 @@ services:
 
   dn3:
     <<: *falcon-common
-    image: falconfs-release-openeuler24.03:v0.1.0
+    image: ${FALCON_RELEASE_IMAGE:-falconfs-release-openeuler24.03:v0.1.0}
     container_name: falcon-dn-3
     hostname: dn-3
     command: [ "bash", "/usr/local/falconfs/falcon_dn/docker-entrypoint.sh" ]


### PR DESCRIPTION
## Summary
This PR adds full release RPM runtime support for both communication plugin paths (brpc/hcom), and removes hcom's hard link-time dependency on `falcon.so` to improve startup robustness.
### Included commits
1. `b6cf9d0`  
   fix: support openEuler release runtime with prebuilt RPM deps
2. `06c85b1`  
   feat: support brpc/hcom runtime switch in release rpm flow
3. `1afd60f`  
   refactor: decouple hcom plugin from falcon.so linkage
## What changed
- Release RPM flow now supports runtime selection between `brpc` and `hcom`.
- CN/DN startup scripts support plugin selection via runtime config/env and write corresponding `falcon_communication.plugin_path`.
- RPM packaging includes both communication plugins for runtime switching in release scenarios.
- `hcom` plugin no longer links with `-l:falcon.so` at build time.
- `hcom` plugin directory resolution is now runtime-based:
  - preferred: `FALCON_PLUGIN_DIRECTORY`
  - fallback: `dlsym(RTLD_DEFAULT, "falcon_plugin_directory")`
## Why
Previously, hcom startup in RPM/release environments could fail with dynamic loading errors (e.g. `falcon.so` resolution issues), and runtime plugin switching was limited.  
This PR makes runtime behavior consistent and reduces environment-specific linkage fragility.
## Verification
- Verified `libhcomplugin.so` no longer has hard `NEEDED: falcon.so` dependency.
liuwei@localhost:~/code/falconfs$ ldd /usr/local/falconfs/falcon_meta/lib/postgresql/libhcomplugin.so
linux-vdso.so.1 (0x00007ffddc308000)
libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007f235e200000)
libm.so.6 => /usr/lib64/libm.so.6 (0x00007f235e123000)
libgcc_s.so.1 => /usr/lib64/libgcc_s.so.1 (0x00007f235e103000)
libc.so.6 => /usr/lib64/libc.so.6 (0x00007f235df2b000)
/lib64/ld-linux-x86-64.so.2 (0x00007f235e474000)

- Local start validated:
  - `./deploy/falcon_start.sh --comm-plugin=hcom`
 2026-04-13 20:17:17.710 CST [1807213] LOG: FalconDaemon2PCFailureCleanupProcessMain: init finished.
2026-04-13 20:17:17.710 CST [1807213] LOG: FalconDaemon2PCFailureCleanupProcessMain: Running.
2026-04-13 20:17:17.811 CST [1807212] LOG: Using plugin /usr/local/falconfs/falcon_meta/lib/postgresql/libhcomplugin.so start CommunicationSever.
[LOG] [FalconHcomServer] In StartFalconCommunicationServer
[Log] [FalconHcomServer] In LoadPlugins
[LOG] [FalconHcomServer] Loading plugin: /home/liuwei/code/falconfs/plugins/libfalcon_meta_service_test_plugin.so
[FalconMetaServiceTestPlugin] plugin_init() called
[FalconMetaServiceTestPlugin] plugin_init() completed
[FalconMetaServiceTestPlugin] plugin_work() called
[FalconMetaServiceTestPlugin] FalconMetaService instance ready

- Release RPM compose path validated with runtime plugin selection (`FALCON_COMM_PLUGIN=hcom`).
liuwei@localhost:~$ docker ps
CONTAINER ID        IMAGE                                    COMMAND                  CREATED             STATUS                  PORTS                                    NAMES
5911efbaab5d        falconfs-release-openeuler24.03:v0.7.0   "bash /usr/local/fal…"   24 hours ago        Up 24 hours (healthy)                                            falcon-dn-3
e31b2b26def6        falconfs-release-openeuler24.03:v0.7.0   "bash /usr/local/fal…"   24 hours ago        Up 24 hours (healthy)                                            falcon-dn-1
e428ba2b51dc        falconfs-release-openeuler24.03:v0.7.0   "bash /usr/local/fal…"   24 hours ago        Up 24 hours (healthy)                                            falcon-dn-2
c98e8bfa1493        falconfs-release-openeuler24.03:v0.7.0   "bash /usr/local/fal…"   24 hours ago        Up 24 hours (healthy)                                            falcon-cn-2
d84c7aa2cfd7        falconfs-release-openeuler24.03:v0.7.0   "bash /usr/local/fal…"   24 hours ago        Up 24 hours (healthy)                                            falcon-cn-3
00ec2a3cfdda        falconfs-release-openeuler24.03:v0.7.0   "bash /usr/local/fal…"   24 hours ago        Up 24 hours (healthy)                                            falcon-cn-1
034912fb0ad1        zookeeper:3.8.3                          "/docker-entrypoint.…"   24 hours ago        Up 24 hours (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp   falcon-zk-3
015577d82505        zookeeper:3.8.3                          "/docker-entrypoint.…"   24 hours ago        Up 24 hours (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp   falcon-zk-1
3d4858e2ad10        zookeeper:3.8.3                          "/docker-entrypoint.…"   24 hours ago        Up 24 hours (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp   falcon-zk-2


## Compatibility
- Existing brpc behavior remains compatible.
- If `FALCON_PLUGIN_DIRECTORY` is not set, behavior falls back to existing GUC-based symbol lookup path.