### PR TITLE
fix(deploy): harden local startup against stale state and lock conflicts

### DIFF
--- a/deploy/client/falcon_client_start.sh
+++ b/deploy/client/falcon_client_start.sh
@@ -4,12 +4,72 @@ set -euo pipefail
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 source "$DIR/falcon_client_config.sh"
 
-# 检查是否已挂载
-if mount | grep -q "$MNT_PATH"; then
-    echo "$MNT_PATH is already mounted"
-else
+is_mounted() {
+    if command -v mountpoint >/dev/null 2>&1; then
+        mountpoint -q "$MNT_PATH" 2>/dev/null
+    else
+        mount | grep -q " $MNT_PATH "
+    fi
+}
+
+get_client_pids() {
+    pgrep -x falcon_client 2>/dev/null || true
+}
+
+stop_stale_clients() {
+    local pids
+    local remaining
+
+    pids="$(get_client_pids)"
+    [ -z "$pids" ] && return 0
+
+    echo "Stopping stale falcon_client process(es): $pids"
+    for pid in $pids; do
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+
+    for _ in {1..5}; do
+        sleep 1
+        remaining="$(get_client_pids)"
+        [ -z "$remaining" ] && return 0
+    done
+
+    echo "Force killing stale falcon_client process(es): $remaining"
+    for pid in $remaining; do
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+}
+
+ensure_mountpoint_writable() {
     mkdir -p "$MNT_PATH" 2>/dev/null || true
+    if [ -w "$MNT_PATH" ]; then
+        return 0
+    fi
+
+    echo "Error: mountpoint $MNT_PATH is not writable. Please run: sudo chown $USER:$(id -gn) $MNT_PATH" >&2
+    exit 1
+}
+
+# already healthy => no-op
+if is_mounted && [ -n "$(get_client_pids)" ]; then
+    echo "falcon_client is already running and mounted at $MNT_PATH"
+    exit 0
 fi
+
+# stale mount without process
+if is_mounted && [ -z "$(get_client_pids)" ]; then
+    echo "Found stale mount at $MNT_PATH without falcon_client process, unmounting..."
+    if ! umount "$MNT_PATH" 2>/dev/null; then
+        umount -l "$MNT_PATH"
+    fi
+fi
+
+# stale process without mount
+if ! is_mounted && [ -n "$(get_client_pids)" ]; then
+    stop_stale_clients
+fi
+
+ensure_mountpoint_writable
 
 # 清理并创建缓存目录
 [ -d "$CACHE_PATH" ] && rm -rf "$CACHE_PATH"
@@ -33,13 +93,15 @@ CLIENT_OPTIONS=(
     -socket_max_unwritten_bytes=268435456
 )
 
-nohup falcon_client "${CLIENT_OPTIONS[@]}" >${DIR}/falcon_client.log 2>&1 &
+nohup falcon_client "${CLIENT_OPTIONS[@]}" >"${DIR}/falcon_client.log" 2>&1 &
+client_pid=$!
 
 sleep 1
-if ! pgrep -f "falcon_client" >/dev/null; then
+if ! kill -0 "$client_pid" 2>/dev/null; then
     echo "Error: Failed to start falcon_client" >&2
+    [ -f "${DIR}/falcon_client.log" ] && tail -n 50 "${DIR}/falcon_client.log" || true
     exit 1
 fi
 
-echo "falcon_client started successfully (PID: $(pgrep -f "^\falcon_client"))"
+echo "falcon_client started successfully (PID: $client_pid)"
 exit 0

--- a/deploy/client/falcon_client_stop.sh
+++ b/deploy/client/falcon_client_stop.sh
@@ -24,7 +24,7 @@ fi
 
 # 2. Kill any remaining falcon_client processes (for unmounted instances)
 sleep 1
-pids=$(pgrep -f "^\falcon_client" | grep -v $$ | grep -v grep || true)
+pids=$(pgrep -x falcon_client || true)
 if [ -n "$pids" ]; then
     for pid in $pids; do
         if ps -p "$pid" >/dev/null; then

--- a/deploy/falcon_start.sh
+++ b/deploy/falcon_start.sh
@@ -2,6 +2,9 @@
 DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
 
 source $DIR/falcon_env.sh
-$DIR/meta/falcon_meta_start.sh "$@"
+if ! $DIR/meta/falcon_meta_start.sh "$@"; then
+    echo "Error: falcon_meta_start failed, skip falcon_client_start" >&2
+    exit 1
+fi
 sleep 3
 $DIR/client/falcon_client_start.sh

--- a/deploy/meta/falcon_meta_start.sh
+++ b/deploy/meta/falcon_meta_start.sh
@@ -50,6 +50,73 @@ if [[ "$COMM_PLUGIN" != "brpc" && "$COMM_PLUGIN" != "hcom" ]]; then
     exit 1
 fi
 
+check_lock_conflict_for_port() {
+    local port="$1"
+    # NOTE: lock file path follows PostgreSQL unix_socket_directories (default /tmp).
+    # If unix_socket_directories is changed in postgresql.conf, update this path accordingly.
+    local lock_file="/tmp/.s.PGSQL.${port}.lock"
+
+    if [ ! -e "$lock_file" ]; then
+        return 0
+    fi
+
+    local owner
+    owner=$(stat -c '%U' "$lock_file" 2>/dev/null || true)
+    if [ -n "$owner" ] && [ "$owner" != "$USER" ]; then
+        echo "Error: detected PostgreSQL lock conflict on $lock_file (owner: $owner, current user: $USER)." >&2
+        exit 1
+    fi
+}
+
+check_local_socket_lock_conflict() {
+    local port
+
+    if [[ "$cnIp" == "$localIp" ]]; then
+        port="${cnPortPrefix}0"
+        check_lock_conflict_for_port "$port"
+    fi
+
+    for ((n = 0; n < ${#workerIpList[@]}; n++)); do
+        if [[ "${workerIpList[$n]}" == "$localIp" ]]; then
+            for ((i = 0; i < ${workerNumList[$n]}; i++)); do
+                port="${workerPortPrefix}${i}"
+                check_lock_conflict_for_port "$port"
+            done
+        fi
+    done
+}
+
+check_local_socket_lock_conflict
+  
+is_local_meta_running() {
+    local path
+
+    if [[ "$cnIp" == "$localIp" ]]; then
+        path="${cnPathPrefix}0"
+        if [ ! -d "$path" ] || ! pg_ctl status -D "$path" >/dev/null 2>&1; then
+            return 1
+        fi
+    fi
+
+    for ((n = 0; n < ${#workerIpList[@]}; n++)); do
+        if [[ "${workerIpList[$n]}" == "$localIp" ]]; then
+            for ((i = 0; i < ${workerNumList[$n]}; i++)); do
+                path="${workerPathPrefix}${i}"
+                if [ ! -d "$path" ] || ! pg_ctl status -D "$path" >/dev/null 2>&1; then
+                    return 1
+                fi
+            done
+        fi
+    done
+
+    return 0
+}
+
+if is_local_meta_running; then
+    echo "Falcon metadata services are already running on local node, skip re-initialization"
+    exit 0
+fi
+
 CPU_HALF=$(( $(nproc) / 2 ))
 [ $CPU_HALF -eq 0 ] && CPU_HALF=32
 FalconConnectionPoolSize=$CPU_HALF
@@ -107,7 +174,11 @@ EOF
     fi
 
     if ! pg_ctl status -D "$cnPath" &>/dev/null; then
-        pg_ctl start -l "$DIR/cnlogfile0.log" -D "$cnPath" -c
+        if ! pg_ctl start -l "$DIR/cnlogfile0.log" -D "$cnPath" -c; then
+            echo "Error: failed to start coordinator PostgreSQL at $cnPath" >&2
+            echo "Hint: check $DIR/cnlogfile0.log" >&2
+            exit 1
+        fi
     fi
 
     if ! psql -d postgres -h "$cnIp" -p "$cnPort" -tAc "SELECT 1 FROM pg_extension WHERE extname='falcon';" | grep -q 1; then
@@ -158,7 +229,11 @@ EOF
             fi
 
             if ! pg_ctl status -D "$workerPath" &>/dev/null; then
-                pg_ctl start -l "${DIR}/workerlogfile${i}.log" -D "${workerPath}" -c
+                if ! pg_ctl start -l "${DIR}/workerlogfile${i}.log" -D "${workerPath}" -c; then
+                    echo "Error: failed to start worker PostgreSQL at $workerPath" >&2
+                    echo "Hint: check ${DIR}/workerlogfile${i}.log" >&2
+                    exit 1
+                fi
             fi
 
             if ! psql -d postgres -h "${workerIp}" -p "${workerPort}" -tAc "SELECT 1 FROM pg_extension WHERE extname='falcon';" | grep -q 1; then


### PR DESCRIPTION
## Summary
- make local `falcon_start` idempotent by skipping re-initialization when local metadata instances are already running
- harden `falcon_client` startup/cleanup for stale mount/process states and writable mountpoint checks
- fail fast before client startup when PostgreSQL socket lock files in `/tmp` are owned by another user
- stop startup chain when `falcon_meta_start` fails so `falcon_client` is not launched on broken metadata
## Key Changes
- `deploy/client/falcon_client_start.sh`
  - add idempotent fast-path for already-mounted running client
  - handle stale mount and stale client process cleanup
  - improve startup PID verification and error logs
- `deploy/client/falcon_client_stop.sh`
  - fix process matching to use `pgrep -x falcon_client`
- `deploy/meta/falcon_meta_start.sh`
  - add local metadata running check to skip re-initialization
  - add pre-start lock owner conflict checks for `/tmp/.s.PGSQL.<port>.lock`
  - return non-zero on `pg_ctl start` failure with clear log hints
- `deploy/falcon_start.sh`
  - guard client startup behind successful metadata startup
## Verification
- validated repeated `./deploy/falcon_start.sh` no longer re-initializes metadata
<img width="775" height="91" alt="image" src="https://github.com/user-attachments/assets/a41207a0-c664-4a43-93f4-70ffed3756d3" />

- validated lock-conflict simulation with another-user-owned `/tmp/.s.PGSQL.55500.lock` fails early with clear error and skips client startup
- validated normal start/stop/start flow with metadata and client healthy