### PR TITLE
fix(deploy): harden start flow for hcom and plugin readiness

### DIFF
--- a/deploy/client/falcon_client_start.sh
+++ b/deploy/client/falcon_client_start.sh
@@ -96,12 +96,14 @@ CLIENT_OPTIONS=(
 nohup falcon_client "${CLIENT_OPTIONS[@]}" >"${DIR}/falcon_client.log" 2>&1 &
 client_pid=$!
 
-sleep 1
-if ! kill -0 "$client_pid" 2>/dev/null; then
-    echo "Error: Failed to start falcon_client" >&2
-    [ -f "${DIR}/falcon_client.log" ] && tail -n 50 "${DIR}/falcon_client.log" || true
-    exit 1
-fi
+for _ in {1..5}; do
+    sleep 1
+    if ! kill -0 "$client_pid" 2>/dev/null; then
+        echo "Error: falcon_client exited during startup" >&2
+        [ -f "${DIR}/falcon_client.log" ] && tail -n 50 "${DIR}/falcon_client.log" || true
+        exit 1
+    fi
+done
 
 echo "falcon_client started successfully (PID: $client_pid)"
 exit 0

--- a/deploy/falcon_start.sh
+++ b/deploy/falcon_start.sh
@@ -2,9 +2,25 @@
 DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
 
 source $DIR/falcon_env.sh
+
+COMM_PLUGIN="brpc"
+for arg in "$@"; do
+    case "$arg" in
+        --comm-plugin=*)
+            COMM_PLUGIN="${arg#*=}"
+            ;;
+    esac
+done
+
 if ! $DIR/meta/falcon_meta_start.sh "$@"; then
     echo "Error: falcon_meta_start failed, skip falcon_client_start" >&2
     exit 1
 fi
+
+if [[ "$COMM_PLUGIN" == "hcom" ]]; then
+    echo "Skip falcon_client_start for hcom mode"
+    exit 0
+fi
+
 sleep 3
 $DIR/client/falcon_client_start.sh

--- a/deploy/meta/falcon_meta_start.sh
+++ b/deploy/meta/falcon_meta_start.sh
@@ -135,6 +135,12 @@ shardcount=50
 
 comm_plugin_path="$FALCONFS_INSTALL_DIR/falcon_meta/lib/postgresql/lib${COMM_PLUGIN}plugin.so"
 
+if [ ! -f "$comm_plugin_path" ]; then
+    echo "Error: communication plugin not found: $comm_plugin_path" >&2
+    echo "Hint: build/install Falcon with --comm-plugin=${COMM_PLUGIN}" >&2
+    exit 1
+fi
+
 # 安装 falcon 扩展到 PostgreSQL 系统目录
 install_falcon_extension
 


### PR DESCRIPTION
## Summary
- Add a communication plugin existence check in metadata startup to fail fast when `lib${COMM_PLUGIN}plugin.so` is missing.
- Skip `falcon_client_start` in `hcom` mode to avoid invalid local startup paths.
- Improve client startup validation from a 1s check to a 5s survival window, and surface logs when early exit happens.
## Why
- Prevent false-positive "startup success" when the communication plugin is absent or initialization fails in background workers.
- Keep startup behavior aligned with `hcom` mode design (metadata-only local startup).
- Make startup failures easier to diagnose and reduce flaky local bring-up behavior.
## Changes
- `deploy/meta/falcon_meta_start.sh`
  - Verify plugin file exists before PostgreSQL extension startup.
- `deploy/falcon_start.sh`
  - Parse `--comm-plugin=...` and skip client startup for `hcom`.
- `deploy/client/falcon_client_start.sh`
  - Replace 1s liveness probe with 5 rounds of checks and better failure message/log tail.
## Validation
- Script syntax checks:
  - `bash -n deploy/falcon_start.sh` when use hcom plugin
  
<img width="976" height="112" alt="image" src="https://github.com/user-attachments/assets/c5ebfd87-35ac-48a4-b9e9-168a36d9040d" />  
  - `./deploy/falcon_start.sh --comm-plugin=hcom` returns success and prints `Skip falcon_client_start for hcom mode`.
  
<img width="818" height="512" alt="image" src="https://github.com/user-attachments/assets/98626daf-b42d-4a62-9a6d-f6dc8e98855a" />
