### PR TITLE
Add metadb coverage tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -624,7 +624,7 @@ clean)
 	esac
 	;;
 test)
-	run_unit_tests
+	run_all_unit_tests
 	;;
 coverage)
 	shift

--- a/deploy/coverage/coverage_common.sh
+++ b/deploy/coverage/coverage_common.sh
@@ -40,7 +40,7 @@ resolve_gcov_tool() {
 	fi
 }
 
-run_non_service_unit_tests() {
+run_standalone_unit_tests() {
 	cd "$FALCONFS_DIR"
 
 	local target_dirs=(
@@ -53,9 +53,11 @@ run_non_service_unit_tests() {
 		if [[ -d "$target_dir" ]]; then
 			echo "Running tests in: $target_dir"
 			find "$target_dir" -type f -executable -name "*UT" | while read -r executable_file; do
-				if [[ "$(basename "$executable_file")" == "LocalRunWorkloadUT" ]]; then
+				case "$(basename "$executable_file")" in
+				LocalRunWorkloadUT | MetadbCoverageUT)
 					continue
-				fi
+					;;
+				esac
 				echo "Executing: $executable_file"
 				"$executable_file"
 				echo "---------------------------------------------------------------------------------------"
@@ -74,15 +76,22 @@ run_non_service_unit_tests() {
 }
 
 run_service_dependent_unit_tests() {
-	local local_run_ut="$FALCONFS_DIR/build/tests/private-directory-test/LocalRunWorkloadUT"
 	local service_server_ip
 	local service_server_port
 	service_server_ip="$(resolve_service_test_server_ip)"
 	service_server_port="$(resolve_service_test_server_port)"
-	if [[ -x "$local_run_ut" ]]; then
-		echo "Running service-dependent tests in: $FALCONFS_DIR/build/tests/private-directory-test/"
-		echo "Service-dependent UT endpoint: ${service_server_ip}:${service_server_port}"
-		echo "Executing: $local_run_ut"
+	local service_uts=(
+		"$FALCONFS_DIR/build/tests/private-directory-test/LocalRunWorkloadUT"
+		"$FALCONFS_DIR/build/tests/falcon/metadb/MetadbCoverageUT"
+	)
+
+	echo "Running service-dependent tests:"
+	echo "Service-dependent UT endpoint: ${service_server_ip}:${service_server_port}"
+	for service_ut in "${service_uts[@]}"; do
+		if [[ ! -x "$service_ut" ]]; then
+			continue
+		fi
+		echo "Executing: $service_ut"
 		SERVER_IP="$service_server_ip" \
 		SERVER_PORT="$service_server_port" \
 		LOCAL_RUN_MOUNT_DIR="${LOCAL_RUN_MOUNT_DIR:-/}" \
@@ -94,13 +103,13 @@ run_service_dependent_unit_tests() {
 		LOCAL_RUN_WAIT_PORT="${LOCAL_RUN_WAIT_PORT:-1111}" \
 		LOCAL_RUN_FILE_SIZE="${LOCAL_RUN_FILE_SIZE:-4096}" \
 		LOCAL_RUN_CLIENT_NUM="${LOCAL_RUN_CLIENT_NUM:-1}" \
-		"$local_run_ut"
+		"$service_ut"
 		echo "---------------------------------------------------------------------------------------"
-	fi
+	done
 }
 
-run_unit_tests() {
-	run_non_service_unit_tests
+run_all_unit_tests() {
+	run_standalone_unit_tests
 	run_service_dependent_unit_tests
 	echo "All unit tests passed."
 }

--- a/deploy/coverage/coverage_report.sh
+++ b/deploy/coverage/coverage_report.sh
@@ -58,12 +58,13 @@ run_coverage() {
 	trap cleanup_coverage_local_service RETURN
 
 	if [[ "$RUN_LOCAL_SERVICE_FOR_COVERAGE" == true ]]; then
+		run_standalone_unit_tests
 		start_local_service_for_coverage
 		local_service_started=true
-		run_unit_tests
-	else
-		run_non_service_unit_tests
+		run_service_dependent_unit_tests
 		echo "All unit tests passed."
+	else
+		run_all_unit_tests
 	fi
 
 	if [[ "$local_service_started" == true ]]; then

--- a/tests/falcon/CMakeLists.txt
+++ b/tests/falcon/CMakeLists.txt
@@ -3,6 +3,8 @@ include(GoogleTest)
 enable_testing()
 link_directories(${POSTGRES_SRC_DIR}/src/interfaces/libpq)
 
+add_subdirectory(metadb)
+
 # ==================== FalconQueueUT =================
 add_executable(FalconQueueUT
     ${PROJECT_SOURCE_DIR}/tests/falcon/test_falcon_concurrent_queue.cpp

--- a/tests/falcon/metadb/CMakeLists.txt
+++ b/tests/falcon/metadb/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_executable(MetadbCoverageUT
+    test_metadb_coverage_ut.cpp
+    test_metadb_coverage_common.cpp
+    test_metadb_dfs_flows_ut.cpp
+    test_metadb_helper_ut.cpp
+    test_metadb_sql_serialized_ut.cpp
+    ${PROJECT_SOURCE_DIR}/falcon/metadb/meta_process_info.c
+    ${PROJECT_SOURCE_DIR}/falcon/metadb/meta_serialize_interface_helper.cpp
+    ${PROJECT_SOURCE_DIR}/falcon/utils/utils_standalone.c
+    ${PROJECT_SOURCE_DIR}/tests/private-directory-test/workloads.cc
+    ${PROJECT_SOURCE_DIR}/tests/private-directory-test/falconfs.cc
+)
+
+target_include_directories(MetadbCoverageUT PUBLIC
+    ${PROJECT_SOURCE_DIR}/tests/private-directory-test
+    ${PROJECT_SOURCE_DIR}/falcon_store/src/include
+    ${PROJECT_SOURCE_DIR}/falcon_client/src/include
+    ${PROJECT_SOURCE_DIR}/common/src/include
+    ${PROJECT_SOURCE_DIR}/falcon/include
+    ${PROJECT_BINARY_DIR}/generated
+    ${POSTGRES_INCLUDE_DIR}
+)
+
+add_dependencies(MetadbCoverageUT GeneratedFlatBuffers)
+
+target_link_libraries(MetadbCoverageUT
+    FalconStore
+    FalconClient
+    FalconStore
+    zookeeper_mt
+    glog
+    jsoncpp
+    gtest
+    pq
+    ${BRPC_LIBRARIES}
+    ${DYNAMIC_LIB}
+)

--- a/tests/falcon/metadb/test_metadb_coverage_common.cpp
+++ b/tests/falcon/metadb/test_metadb_coverage_common.cpp
@@ -1,0 +1,341 @@
+#include "test_metadb_coverage_common.h"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <thread>
+
+int thread_num = 1;
+int client_cache_size = 16384;
+int files_per_dir = 2;
+int file_size = 4096;
+int file_num = 0;
+std::atomic<bool> printed(false);
+volatile uint64_t op_count[16384];
+volatile uint64_t latency_count[16384];
+
+namespace metadb_test {
+
+namespace {
+std::atomic<uint64_t> g_case_counter(0);
+local_run_test::LocalRunParameters g_params;
+}  // 匿名命名空间
+
+std::string BuildRootPath(const char *tag)
+{
+    uint64_t seq = g_case_counter.fetch_add(1, std::memory_order_relaxed);
+    return fmt::format("{}metadb_{}_{}_{}_{}_{}_{}/",
+                       g_params.mount_dir, g_params.client_id, g_params.wait_port,
+                       tag, getpid(), seq, time(nullptr));
+}
+
+std::string ThreadDir(const std::string &root, int thread_id)
+{
+    return fmt::format("{}thread_{}", root, thread_id);
+}
+
+std::string FilePath(const std::string &root, int thread_id, int file_id)
+{
+    return fmt::format("{}/file_{}", ThreadDir(root, thread_id), file_id);
+}
+
+std::string DirPath(const std::string &root, int thread_id, int dir_id)
+{
+    return fmt::format("{}/dir_{}", ThreadDir(root, thread_id), dir_id);
+}
+
+SerializedDataGuard::SerializedDataGuard() { EXPECT_TRUE(SerializedDataInit(&data_, nullptr, 0, 0, nullptr)); }
+SerializedDataGuard::~SerializedDataGuard() { SerializedDataDestroy(&data_); }
+SerializedData *SerializedDataGuard::get() { return &data_; }
+
+void InitNamespaceRoot(const std::string &root)
+{
+    int saved_files_per_dir = files_per_dir;
+    files_per_dir = 1 + thread_num;
+    workload_init(root, 0);
+    files_per_dir = saved_files_per_dir;
+}
+
+void UninitNamespaceRoot(const std::string &root)
+{
+    int saved_files_per_dir = files_per_dir;
+    files_per_dir = 1 + thread_num;
+    workload_uninit(root, 0);
+    files_per_dir = saved_files_per_dir;
+}
+
+bool InitClientOrSkip()
+{
+    setenv("SERVER_IP", local_run_test::GetEnvOrDefault("SERVER_IP", "127.0.0.1").c_str(), 1);
+    setenv("SERVER_PORT", local_run_test::GetEnvOrDefault("SERVER_PORT", "55500").c_str(), 1);
+    g_params = local_run_test::LoadLocalRunParameters();
+    local_run_test::ResetCounters();
+
+    constexpr int kMaxRetry = 6;
+    for (int i = 0; i < kMaxRetry; ++i) {
+        try {
+            if (dfs_init(g_params.client_num) == 0) {
+                return true;
+            }
+        } catch (...) {
+        }
+        dfs_shutdown();
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    return false;
+}
+
+void CleanupRoot(const std::string &root, const std::string &file_path, const std::string &dir_path)
+{
+    try {
+        dfs_unlink(file_path.c_str());
+        dfs_rmdir(dir_path.c_str());
+        UninitNamespaceRoot(root);
+    } catch (...) {
+    }
+    dfs_shutdown();
+}
+
+std::string SqlQuote(const std::string &value)
+{
+    std::string quoted = "'";
+    for (char ch : value) {
+        if (ch == '\'') {
+            quoted += "''";
+        } else {
+            quoted += ch;
+        }
+    }
+    quoted += "'";
+    return quoted;
+}
+
+std::string HexEncode(const std::vector<uint8_t> &bytes)
+{
+    std::ostringstream out;
+    out << std::hex << std::setfill('0');
+    for (uint8_t byte : bytes) {
+        out << std::setw(2) << static_cast<int>(byte);
+    }
+    return out.str();
+}
+
+std::vector<uint8_t> WrapSerializedItem(const flatbuffers::FlatBufferBuilder &builder)
+{
+    uint32_t payload_size = static_cast<uint32_t>(builder.GetSize());
+    uint32_t aligned_size = (payload_size + 3U) & ~3U;
+    std::vector<uint8_t> bytes(sizeof(uint32_t) + aligned_size, 0);
+    bytes[0] = static_cast<uint8_t>(aligned_size & 0xFFU);
+    bytes[1] = static_cast<uint8_t>((aligned_size >> 8U) & 0xFFU);
+    bytes[2] = static_cast<uint8_t>((aligned_size >> 16U) & 0xFFU);
+    bytes[3] = static_cast<uint8_t>((aligned_size >> 24U) & 0xFFU);
+    std::copy(builder.GetBufferPointer(), builder.GetBufferPointer() + payload_size, bytes.begin() + sizeof(uint32_t));
+    return bytes;
+}
+
+std::vector<uint8_t> BuildPathOnlyParam(const std::string &path)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreatePathOnlyParamDirect(builder, path.c_str());
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_PathOnlyParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildCloseParam(const std::string &path, int64_t size, uint64_t mtime, int32_t node_id)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateCloseParamDirect(builder, path.c_str(), size, mtime, node_id);
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_CloseParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildReadDirParam(const std::string &path, int32_t max_read_count,
+                                       int32_t last_shard_index, const std::string &last_file_name)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateReadDirParamDirect(builder, path.c_str(), max_read_count,
+                                                            last_shard_index, last_file_name.c_str());
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_ReadDirParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildRenameParam(const std::string &src, const std::string &dst)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateRenameParamDirect(builder, src.c_str(), dst.c_str());
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_RenameParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildUtimeNsParam(const std::string &path, uint64_t atime, uint64_t mtime)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateUtimeNsParam(builder, builder.CreateString(path), atime, mtime);
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_UtimeNsParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildChownParam(const std::string &path, uint32_t uid, uint32_t gid)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateChownParamDirect(builder, path.c_str(), uid, gid);
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_ChownParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildChmodParam(const std::string &path, uint64_t mode)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateChmodParam(builder, builder.CreateString(path), mode);
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_ChmodParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildKvParam(const std::string &key, uint32_t value_len,
+                                  const std::vector<uint64_t> &value_key,
+                                  const std::vector<uint64_t> &location,
+                                  const std::vector<uint32_t> &size)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateKVParamDirect(builder, key.c_str(), value_len,
+                                                       static_cast<uint16_t>(value_key.size()), &value_key,
+                                                       &location, &size);
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_KVParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildKeyOnlyParam(const std::string &key)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateKeyOnlyParamDirect(builder, key.c_str());
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_KeyOnlyParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildSliceInfoParam(const std::string &name, const std::vector<uint64_t> &inode_id,
+                                         const std::vector<uint32_t> &chunk_id,
+                                         const std::vector<uint64_t> &slice_id,
+                                         const std::vector<uint32_t> &slice_size,
+                                         const std::vector<uint32_t> &slice_offset,
+                                         const std::vector<uint32_t> &slice_len,
+                                         const std::vector<uint32_t> &slice_loc1,
+                                         const std::vector<uint32_t> &slice_loc2)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateSliceInfoParamDirect(builder, name.c_str(),
+                                                              static_cast<uint32_t>(inode_id.size()), &inode_id,
+                                                              &chunk_id, &slice_id, &slice_size, &slice_offset,
+                                                              &slice_len, &slice_loc1, &slice_loc2);
+    auto meta =
+        falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_SliceInfoParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildSliceIndexParam(const std::string &name, uint64_t inode_id, uint32_t chunk_id)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateSliceIndexParamDirect(builder, name.c_str(), inode_id, chunk_id);
+    auto meta =
+        falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_SliceIndexParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+std::vector<uint8_t> BuildSliceIdParam(uint32_t count, uint8_t type)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto param = falcon::meta_fbs::CreateSliceIdParam(builder, count, type);
+    auto meta = falcon::meta_fbs::CreateMetaParam(builder, falcon::meta_fbs::AnyMetaParam_SliceIdParam, param.Union());
+    builder.Finish(meta);
+    return WrapSerializedItem(builder);
+}
+
+PgConnection::PgConnection(const std::string &host, int port)
+{
+    std::ostringstream conninfo;
+    conninfo << "host=" << host << " port=" << port << " dbname=postgres connect_timeout=3";
+    conn_.reset(PQconnectdb(conninfo.str().c_str()));
+}
+
+bool PgConnection::IsOpen() const
+{
+    return conn_ != nullptr && PQstatus(conn_.get()) == CONNECTION_OK;
+}
+
+std::string PgConnection::ErrorMessage() const
+{
+    return conn_ ? PQerrorMessage(conn_.get()) : "connection is null";
+}
+
+bool PgConnection::ExecOk(const std::string &sql)
+{
+    std::unique_ptr<PGresult, decltype(&PQclear)> result(PQexec(conn_.get(), sql.c_str()), PQclear);
+    if (!result) {
+        return false;
+    }
+    ExecStatusType status = PQresultStatus(result.get());
+    return status == PGRES_COMMAND_OK || status == PGRES_TUPLES_OK;
+}
+
+bool PgConnection::ScalarText(const std::string &sql, std::string *value)
+{
+    std::unique_ptr<PGresult, decltype(&PQclear)> result(PQexec(conn_.get(), sql.c_str()), PQclear);
+    if (!result || PQresultStatus(result.get()) != PGRES_TUPLES_OK || PQntuples(result.get()) != 1) {
+        return false;
+    }
+    if (value) {
+        *value = PQgetvalue(result.get(), 0, 0);
+    }
+    return true;
+}
+
+bool PgConnection::ScalarInt(const std::string &sql, int *value)
+{
+    std::string text;
+    if (!ScalarText(sql, &text)) {
+        return false;
+    }
+    if (value) {
+        *value = std::atoi(text.c_str());
+    }
+    return true;
+}
+
+bool PgConnection::SerializedCall(FalconMetaServiceType type, const std::vector<uint8_t> &param, int *response_size)
+{
+    return ScalarInt("SELECT octet_length(falcon_meta_call_by_serialized_data(" +
+                         std::to_string(static_cast<int>(type)) + ", 1, decode('" + HexEncode(param) + "', 'hex')))",
+                     response_size);
+}
+
+bool ConnectPlainSql(int pg_port, PgConnection *&connection_holder, std::unique_ptr<PgConnection> &owner)
+{
+    std::string ip = local_run_test::GetEnvOrDefault("SERVER_IP", "127.0.0.1");
+    if (!local_run_test::WaitForEndpoint(ip, pg_port, 6)) {
+        return false;
+    }
+
+    owner = std::make_unique<PgConnection>(ip, pg_port);
+    if (!owner->IsOpen()) {
+        return false;
+    }
+    connection_holder = owner.get();
+    return true;
+}
+
+}  // 命名空间 metadb_test

--- a/tests/falcon/metadb/test_metadb_coverage_common.h
+++ b/tests/falcon/metadb/test_metadb_coverage_common.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "dfs.h"
+#include "falcon_meta_param_generated.h"
+#include "local_run_workload_test_common.h"
+#include "utils/falcon_meta_service_def.h"
+
+extern "C" {
+#include "metadb/meta_process_info.h"
+}
+
+#include "metadb/meta_serialize_interface_helper.h"
+
+#include <gtest/gtest.h>
+#include <libpq-fe.h>
+#include <fmt/format.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+extern int thread_num;
+extern int client_cache_size;
+extern int files_per_dir;
+extern int file_size;
+extern int file_num;
+extern std::atomic<bool> printed;
+extern volatile uint64_t op_count[16384];
+extern volatile uint64_t latency_count[16384];
+
+namespace metadb_test {
+
+std::string BuildRootPath(const char *tag);
+std::string ThreadDir(const std::string &root, int thread_id);
+std::string FilePath(const std::string &root, int thread_id, int file_id);
+std::string DirPath(const std::string &root, int thread_id, int dir_id);
+
+class SerializedDataGuard {
+  public:
+    SerializedDataGuard();
+    ~SerializedDataGuard();
+    SerializedData *get();
+
+  private:
+    SerializedData data_{};
+};
+
+void InitNamespaceRoot(const std::string &root);
+void UninitNamespaceRoot(const std::string &root);
+bool InitClientOrSkip();
+void CleanupRoot(const std::string &root, const std::string &file_path, const std::string &dir_path);
+std::string SqlQuote(const std::string &value);
+std::string HexEncode(const std::vector<uint8_t> &bytes);
+
+std::vector<uint8_t> BuildPathOnlyParam(const std::string &path);
+std::vector<uint8_t> BuildCloseParam(const std::string &path, int64_t size, uint64_t mtime, int32_t node_id);
+std::vector<uint8_t> BuildReadDirParam(const std::string &path, int32_t max_read_count,
+                                       int32_t last_shard_index, const std::string &last_file_name);
+std::vector<uint8_t> BuildRenameParam(const std::string &src, const std::string &dst);
+std::vector<uint8_t> BuildUtimeNsParam(const std::string &path, uint64_t atime, uint64_t mtime);
+std::vector<uint8_t> BuildChownParam(const std::string &path, uint32_t uid, uint32_t gid);
+std::vector<uint8_t> BuildChmodParam(const std::string &path, uint64_t mode);
+std::vector<uint8_t> BuildKvParam(const std::string &key, uint32_t value_len,
+                                  const std::vector<uint64_t> &value_key,
+                                  const std::vector<uint64_t> &location,
+                                  const std::vector<uint32_t> &size);
+std::vector<uint8_t> BuildKeyOnlyParam(const std::string &key);
+std::vector<uint8_t> BuildSliceInfoParam(const std::string &name, const std::vector<uint64_t> &inode_id,
+                                         const std::vector<uint32_t> &chunk_id,
+                                         const std::vector<uint64_t> &slice_id,
+                                         const std::vector<uint32_t> &slice_size,
+                                         const std::vector<uint32_t> &slice_offset,
+                                         const std::vector<uint32_t> &slice_len,
+                                         const std::vector<uint32_t> &slice_loc1,
+                                         const std::vector<uint32_t> &slice_loc2);
+std::vector<uint8_t> BuildSliceIndexParam(const std::string &name, uint64_t inode_id, uint32_t chunk_id);
+std::vector<uint8_t> BuildSliceIdParam(uint32_t count, uint8_t type);
+
+class PgConnection {
+  public:
+    PgConnection(const std::string &host, int port);
+    bool IsOpen() const;
+    std::string ErrorMessage() const;
+    bool ExecOk(const std::string &sql);
+    bool ScalarText(const std::string &sql, std::string *value);
+    bool ScalarInt(const std::string &sql, int *value);
+    bool SerializedCall(FalconMetaServiceType type, const std::vector<uint8_t> &param, int *response_size);
+
+  private:
+    std::unique_ptr<PGconn, decltype(&PQfinish)> conn_{nullptr, PQfinish};
+};
+
+bool ConnectPlainSql(int pg_port, PgConnection *&connection_holder, std::unique_ptr<PgConnection> &owner);
+
+}  // 命名空间 metadb_test

--- a/tests/falcon/metadb/test_metadb_coverage_ut.cpp
+++ b/tests/falcon/metadb/test_metadb_coverage_ut.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/falcon/metadb/test_metadb_dfs_flows_ut.cpp
+++ b/tests/falcon/metadb/test_metadb_dfs_flows_ut.cpp
@@ -1,0 +1,830 @@
+#include "test_metadb_coverage_common.h"
+
+#include <algorithm>
+#include <thread>
+
+using namespace metadb_test;
+
+namespace {
+
+bool PrepareDfsClient()
+{
+    constexpr int kRetry = 2;
+    for (int attempt = 0; attempt < kRetry; ++attempt) {
+        if (!local_run_test::EnsureConfiguredServer()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+        if (InitClientOrSkip()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    return false;
+}
+
+void CleanupPaths(const std::vector<std::string> &files, const std::vector<std::string> &dirs, const std::string &root)
+{
+    for (const auto &path : files) {
+        dfs_unlink(path.c_str());
+    }
+    for (auto it = dirs.rbegin(); it != dirs.rend(); ++it) {
+        dfs_rmdir(it->c_str());
+    }
+    try {
+        UninitNamespaceRoot(root);
+    } catch (...) {
+    }
+    dfs_shutdown();
+}
+
+}  // 匿名命名空间
+
+TEST(MetadbCoverageUT, DirectoryCreateListRemoveFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-001 创建一级目录成功: 创建目录，并验证目录可以 opendir;
+     * - TC-DIR-005 READDIR 返回目录项完整: 验证新建文件和目录都出现在目录项中;
+     * - TC-DIR-006 删除空目录成功: 删除空目录并拆除命名空间;
+     * - TC-FILE-001 CREATE 成功并可见 / TC-FILE-006 UNLINK 删除后不可见。
+     *
+     * 该用例只覆盖目录创建、遍历和删除的基础生命周期。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("dir_create_list_remove");
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string thread_dir = ThreadDir(root, 0);
+        std::string file = FilePath(root, 0, 0);
+        std::string dir = DirPath(root, 0, 0);
+
+        // TC-FILE-001: 创建文件，供目录遍历验证。
+        ASSERT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+        // TC-DIR-001: 创建一级目录，并验证目录可打开。
+        ASSERT_EQ(dfs_mkdir(dir.c_str(), 0755), 0);
+        dirs.push_back(dir);
+        uint64_t dir_inode = 0;
+        EXPECT_EQ(dfs_opendir(thread_dir.c_str(), &dir_inode), 0);
+        EXPECT_NE(dir_inode, 0U);
+
+        // TC-DIR-005: readdir 结果应包含刚创建的文件和目录。
+        std::vector<std::string> entries;
+        ASSERT_EQ(dfs_readdir(thread_dir.c_str(), &entries), 0);
+        EXPECT_NE(std::find(entries.begin(), entries.end(), "file_0"), entries.end());
+        EXPECT_NE(std::find(entries.begin(), entries.end(), "dir_0"), entries.end());
+
+        // TC-FILE-006 / TC-DIR-006: 删除文件和空目录，清理后根目录可拆除。
+        EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+        files.clear();
+        EXPECT_EQ(dfs_rmdir(dir.c_str()), 0);
+        dirs.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "directory create/list/remove flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, dirs, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, FileAttributeUpdateFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-ATTR-001 UTIMENS 更新并校验;
+     * - TC-ATTR-002 CHMOD 更新并校验;
+     * - TC-ATTR-003 CHOWN 更新并校验。
+     *
+     * 该用例只覆盖文件属性更新和 stat 校验。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("file_attribute_update");
+    std::vector<std::string> files;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string file = FilePath(root, 0, 0);
+        ASSERT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+
+        // TC-ATTR-002 / TC-ATTR-003 / TC-ATTR-001: 分别覆盖 chmod、chown、utimens。
+        EXPECT_EQ(dfs_chmod(file.c_str(), 0600), 0);
+        EXPECT_EQ(dfs_chown(file.c_str(), static_cast<uint32_t>(getuid()), static_cast<uint32_t>(getgid())), 0);
+        EXPECT_EQ(dfs_utimens(file.c_str(), 1609459200000000000LL, 1640995200000000000LL), 0);
+
+        // TC-ATTR-001/002/003: 通过 stat 校验属性更新结果。
+        struct stat stbuf;
+        ASSERT_EQ(dfs_stat(file.c_str(), &stbuf), 0);
+        EXPECT_EQ(stbuf.st_mode & 0777, 0600);
+        EXPECT_EQ(stbuf.st_uid, getuid());
+        EXPECT_EQ(stbuf.st_gid, getgid());
+
+        EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+        files.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "file attribute update flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, {}, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, FileAndDirectoryRenameFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-REN-001 同目录文件重命名成功: 旧路径不可见，新路径可见;
+     * - TC-REN-001 同目录目录重命名成功: 旧目录不可打开，新目录可打开。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("file_dir_rename");
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string thread_dir = ThreadDir(root, 0);
+        std::string file_src = FilePath(root, 0, 0);
+        std::string file_dst = fmt::format("{}/file_renamed", thread_dir);
+        std::string dir_src = DirPath(root, 0, 0);
+        std::string dir_dst = fmt::format("{}/dir_renamed", thread_dir);
+        struct stat stbuf;
+
+        ASSERT_EQ(dfs_create(file_src.c_str(), 0644), 0);
+        files.push_back(file_src);
+        ASSERT_EQ(dfs_mkdir(dir_src.c_str(), 0755), 0);
+        dirs.push_back(dir_src);
+
+        // TC-REN-001: 文件 rename 后旧路径 stat 失败，新路径 stat 成功。
+        EXPECT_EQ(dfs_rename(file_src.c_str(), file_dst.c_str()), 0);
+        files[0] = file_dst;
+        EXPECT_NE(dfs_stat(file_src.c_str(), &stbuf), 0);
+        EXPECT_EQ(dfs_stat(file_dst.c_str(), &stbuf), 0);
+
+        // TC-REN-001: 目录 rename 后旧路径 opendir 失败，新路径 opendir 成功。
+        uint64_t dir_inode = 0;
+        EXPECT_EQ(dfs_rename(dir_src.c_str(), dir_dst.c_str()), 0);
+        dirs[0] = dir_dst;
+        EXPECT_NE(dfs_opendir(dir_src.c_str(), nullptr), 0);
+        EXPECT_EQ(dfs_opendir(dir_dst.c_str(), &dir_inode), 0);
+
+        EXPECT_EQ(dfs_unlink(file_dst.c_str()), 0);
+        files.clear();
+        EXPECT_EQ(dfs_rmdir(dir_dst.c_str()), 0);
+        dirs.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "file/directory rename flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, dirs, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, MissingPathAttributeAndRenameFailureFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-ATTR-004 不存在路径属性更新失败;
+     * - TC-REN-003 源不存在重命名失败;
+     * - TC-DIR-004/TC-FILE-003 不存在路径访问失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("missing_attr_rename");
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string missing = fmt::format("{}/missing", ThreadDir(root, 0));
+
+        // TC-DIR-004 / TC-FILE-003: 不存在路径不能 opendir/readdir。
+        EXPECT_NE(dfs_opendir(missing.c_str(), nullptr), 0);
+        EXPECT_NE(dfs_readdir(missing.c_str(), nullptr), 0);
+        // TC-REN-003: 源路径不存在时 rename 失败。
+        EXPECT_NE(dfs_rename(missing.c_str(), fmt::format("{}/dst", ThreadDir(root, 0)).c_str()), 0);
+        // TC-ATTR-004: 不存在路径上的属性更新失败。
+        EXPECT_NE(dfs_chmod(missing.c_str(), 0644), 0);
+        EXPECT_NE(dfs_chown(missing.c_str(), 1000, 1000), 0);
+        EXPECT_NE(dfs_utimens(missing.c_str(), 1, 1), 0);
+
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "missing path attribute/rename flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths({}, {}, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, DuplicateCreateAndMkdirFailureFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-FILE-002 重复 CREATE 失败;
+     * - TC-DIR-002 重复创建同名目录失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("duplicate_create_mkdir");
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string file = FilePath(root, 0, 0);
+        std::string dir = DirPath(root, 0, 0);
+
+        // TC-FILE-002: 第一次 create 成功，重复 create 失败。
+        EXPECT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+        EXPECT_NE(dfs_create(file.c_str(), 0644), 0);
+        // TC-DIR-002: 第一次 mkdir 成功，重复 mkdir 失败。
+        EXPECT_EQ(dfs_mkdir(dir.c_str(), 0755), 0);
+        dirs.push_back(dir);
+        EXPECT_NE(dfs_mkdir(dir.c_str(), 0755), 0);
+
+        EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+        files.clear();
+        EXPECT_EQ(dfs_rmdir(dir.c_str()), 0);
+        dirs.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "duplicate create/mkdir flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, dirs, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, MissingPathOperationFailureFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-FILE-003 父路径不存在 CREATE 失败;
+     * - TC-DIR-003 父目录不存在时创建失败;
+     * - TC-REN-003 源不存在重命名失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("missing_path_ops");
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string thread_dir = ThreadDir(root, 0);
+        std::string missing = fmt::format("{}/missing", thread_dir);
+        std::string missing_child_dir = fmt::format("{}/child_dir", missing);
+        std::string missing_child_file = fmt::format("{}/child_file", missing);
+        struct stat stbuf;
+
+        // TC-FILE-003: 不存在路径上的 stat/open/unlink/rmdir/create 均失败。
+        EXPECT_NE(dfs_stat(missing.c_str(), &stbuf), 0);
+        EXPECT_NE(dfs_open(missing.c_str(), O_RDONLY, 0), 0);
+        EXPECT_NE(dfs_unlink(missing.c_str()), 0);
+        EXPECT_NE(dfs_rmdir(missing.c_str()), 0);
+        EXPECT_NE(dfs_create(missing_child_file.c_str(), 0644), 0);
+        EXPECT_NE(dfs_stat(missing_child_file.c_str(), &stbuf), 0);
+        // TC-DIR-003: 父目录不存在时 mkdir 失败且不残留。
+        EXPECT_NE(dfs_mkdir(missing_child_dir.c_str(), 0755), 0);
+        EXPECT_NE(dfs_stat(missing_child_dir.c_str(), &stbuf), 0);
+        // TC-REN-003: 源路径不存在时 rename 失败。
+        EXPECT_NE(dfs_rename(missing.c_str(), fmt::format("{}/dst", thread_dir).c_str()), 0);
+
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "missing path operation flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths({}, {}, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, TypeMismatchAndNonEmptyDirectoryFailureFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-004 对文件执行 OPENDIR 失败;
+     * - TC-FILE-004 对目录执行 OPEN 的当前实现行为;
+     * - TC-DIR-007 删除非空目录失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("type_mismatch_nonempty");
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string file = FilePath(root, 0, 0);
+        std::string dir = DirPath(root, 0, 0);
+        std::string nested_file = fmt::format("{}/nested_file", dir);
+
+        ASSERT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+        ASSERT_EQ(dfs_mkdir(dir.c_str(), 0755), 0);
+        dirs.push_back(dir);
+
+        // TC-DIR-004: 普通文件不能作为目录打开。
+        EXPECT_NE(dfs_opendir(file.c_str(), nullptr), 0);
+        // TC-FILE-004: 当前 dfs_open 层可能接受目录路径，若返回句柄则关闭。
+        int dir_fd = dfs_open(dir.c_str(), O_RDONLY, 0);
+        if (dir_fd >= 0) {
+            EXPECT_EQ(dfs_close(dir_fd, dir.c_str()), 0);
+        }
+        // TC-DIR-007: 非空目录 rmdir 失败。
+        ASSERT_EQ(dfs_create(nested_file.c_str(), 0644), 0);
+        files.push_back(nested_file);
+        EXPECT_NE(dfs_rmdir(dir.c_str()), 0);
+
+        EXPECT_EQ(dfs_unlink(nested_file.c_str()), 0);
+        files.pop_back();
+        EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+        files.clear();
+        EXPECT_EQ(dfs_rmdir(dir.c_str()), 0);
+        dirs.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "type mismatch/non-empty directory flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, dirs, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, CrossDirectoryRenameAndConflictFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-REN-002 跨目录重命名成功;
+     * - TC-REN-003 目标已存在时 rename 失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("cross_dir_rename_conflict");
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string file = FilePath(root, 0, 0);
+        std::string other_file = FilePath(root, 0, 1);
+        std::string other_dir = DirPath(root, 0, 1);
+        std::string moved_file = fmt::format("{}/moved_file", other_dir);
+        struct stat stbuf;
+
+        ASSERT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+        ASSERT_EQ(dfs_mkdir(other_dir.c_str(), 0755), 0);
+        dirs.push_back(other_dir);
+
+        // TC-REN-002: 文件跨目录移动后旧路径不可见，新路径可见。
+        EXPECT_EQ(dfs_rename(file.c_str(), moved_file.c_str()), 0);
+        files[0] = moved_file;
+        EXPECT_EQ(dfs_stat(moved_file.c_str(), &stbuf), 0);
+        EXPECT_NE(dfs_stat(file.c_str(), &stbuf), 0);
+
+        // TC-REN-003: 目标路径已存在时 rename 失败。
+        ASSERT_EQ(dfs_create(other_file.c_str(), 0644), 0);
+        files.push_back(other_file);
+        EXPECT_NE(dfs_rename(moved_file.c_str(), other_file.c_str()), 0);
+
+        for (const auto &path : files) {
+            EXPECT_EQ(dfs_unlink(path.c_str()), 0);
+        }
+        files.clear();
+        EXPECT_EQ(dfs_rmdir(other_dir.c_str()), 0);
+        dirs.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "cross-directory rename/conflict flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, dirs, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, KvPutDeleteBoundaryFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-KV-001 KV_PUT 新 key 成功;
+     * - TC-KV-003 KV_DEL 删除后不可读;
+     * - TC-KV-004 重复 key PUT 语义。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("kv_put_delete_boundary");
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string key = fmt::format("{}kv_boundary_key", ThreadDir(root, 0));
+        uint64_t value_key = 11;
+        uint64_t location = 22;
+        uint32_t size = 33;
+
+        // TC-KV-003: 不存在 key 读取和删除失败。
+        EXPECT_NE(dfs_kv_get(key.c_str(), nullptr, nullptr), 0);
+        EXPECT_NE(dfs_kv_del(key.c_str()), 0);
+        // TC-KV-001 / TC-KV-004: 新 key put 成功，重复 put 保持当前幂等语义。
+        EXPECT_EQ(dfs_kv_put(key.c_str(), 4096, 1, &value_key, &location, &size), 0);
+        EXPECT_EQ(dfs_kv_put(key.c_str(), 4096, 1, &value_key, &location, &size), 0);
+        EXPECT_EQ(dfs_kv_del(key.c_str()), 0);
+        EXPECT_NE(dfs_kv_del(key.c_str()), 0);
+
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "KV put/delete boundary flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths({}, {}, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, SlicePutGetDeleteBoundaryFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-SLICE-001 单线程 FETCH_SLICE_ID;
+     * - TC-SLICE-004 SLICE_PUT 后 GET 一致;
+     * - TC-SLICE-005 SLICE_DEL 删除后 GET 失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("slice_put_get_delete");
+    std::vector<std::string> files;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string file = FilePath(root, 0, 0);
+        ASSERT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+
+        // TC-SLICE-001: 单线程分配指定数量的 slice-id。
+        uint64_t slice_start = 0;
+        uint64_t slice_end = 0;
+        ASSERT_EQ(dfs_fetch_slice_id(2, &slice_start, &slice_end), 0);
+        EXPECT_EQ(slice_end - slice_start, 2U);
+        // TC-SLICE-005: 不存在 slice 查询失败，删除保持当前幂等语义。
+        EXPECT_NE(dfs_slice_get(file.c_str(), 9999, 9999, nullptr), 0);
+        EXPECT_EQ(dfs_slice_del(file.c_str(), 9999, 9999), 0);
+        // TC-SLICE-004 / TC-SLICE-005: put 后可 get，delete 后再次 delete 保持当前行为。
+        EXPECT_EQ(dfs_slice_put(file.c_str(), 9999, 9, slice_start, 4096, 0, 4096), 0);
+        uint32_t slice_num = 0;
+        EXPECT_EQ(dfs_slice_get(file.c_str(), 9999, 9, &slice_num), 0);
+        EXPECT_GT(slice_num, 0U);
+        EXPECT_EQ(dfs_slice_del(file.c_str(), 9999, 9), 0);
+        EXPECT_EQ(dfs_slice_del(file.c_str(), 9999, 9), 0);
+
+        EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+        files.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "slice put/get/delete boundary flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, {}, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, UnlinkMakesFileInvisibleFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-FILE-006 UNLINK 删除后不可见: unlink 后 stat/open 均失败。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("unlink_invisible");
+    std::vector<std::string> files;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string file = FilePath(root, 0, 0);
+        ASSERT_EQ(dfs_create(file.c_str(), 0644), 0);
+        files.push_back(file);
+        EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+        files.clear();
+
+        // TC-FILE-006: 删除后 stat/open 都应失败。
+        struct stat stbuf;
+        EXPECT_NE(dfs_stat(file.c_str(), &stbuf), 0);
+        EXPECT_NE(dfs_open(file.c_str(), O_RDONLY, 0), 0);
+
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "unlink invisible flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, {}, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+TEST(MetadbCoverageUT, DeepPathFileLifecycleFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-FILE-009 深层路径文件生命周期: 深层路径上的 create/stat/open/close/unlink 成功。
+     */
+    if (!PrepareDfsClient()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("deep_path_file_lifecycle");
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        std::string current = ThreadDir(root, 0);
+        for (const char *part : {"a", "b", "c", "d", "e"}) {
+            current = fmt::format("{}/{}", current, part);
+            ASSERT_EQ(dfs_mkdir(current.c_str(), 0755), 0);
+            dirs.push_back(current);
+        }
+
+        // TC-FILE-009: 深层路径文件 create/stat/open/close/unlink 生命周期。
+        std::string deep_file = fmt::format("{}/file_deep", current);
+        ASSERT_EQ(dfs_create(deep_file.c_str(), 0644), 0);
+        files.push_back(deep_file);
+        struct stat stbuf;
+        EXPECT_EQ(dfs_stat(deep_file.c_str(), &stbuf), 0);
+        EXPECT_EQ(dfs_open(deep_file.c_str(), O_RDONLY, 0), 0);
+        EXPECT_EQ(dfs_close(0, deep_file.c_str()), 0);
+        EXPECT_EQ(dfs_unlink(deep_file.c_str()), 0);
+        files.clear();
+        EXPECT_NE(dfs_stat(deep_file.c_str(), &stbuf), 0);
+
+        for (auto it = dirs.rbegin(); it != dirs.rend(); ++it) {
+            EXPECT_EQ(dfs_rmdir(it->c_str()), 0);
+        }
+        dirs.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "deep path file lifecycle flow threw an exception";
+    }
+
+    if (!namespace_removed) {
+        CleanupPaths(files, dirs, root);
+    } else {
+        dfs_shutdown();
+    }
+}
+
+
+TEST(MetadbCoverageUT, ConcurrentDirectoryAndFileCreateFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-008 并发创建同名目录: 多线程并发 mkdir 同一路径时只有一个成功;
+     * - TC-FILE-007 并发创建同名文件: 多线程并发 create 同一路径时只有一个成功。
+     *
+     * 该流程在 local-run 服务上启动一个 DFS 客户端，创建独立命名空间根目录，
+     * 然后让多个线程竞争同一个目录名和文件名。预期结果是元数据创建只成功一次，
+     * 其余调用返回已存在类错误。dfs_shutdown 前会清理所有创建的目录项。
+     */
+    if (!local_run_test::EnsureConfiguredServer()) {
+        GTEST_SKIP() << "local-run service is not configured";
+    }
+    if (!InitClientOrSkip()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    std::string root = BuildRootPath("dt_concurrent_create_flow");
+    bool namespace_removed = false;
+    std::string same_dir;
+    std::string same_file;
+    try {
+        InitNamespaceRoot(root);
+        std::string thread_dir = ThreadDir(root, 0);
+        same_dir = fmt::format("{}/same_dir", thread_dir);
+        same_file = fmt::format("{}/same_file", thread_dir);
+
+        constexpr int kThreads = 8;
+        std::atomic<int> mkdir_success(0);
+        std::atomic<int> mkdir_failure(0);
+        std::vector<std::thread> workers;
+        for (int i = 0; i < kThreads; ++i) {
+            workers.emplace_back([&]() {
+                if (dfs_mkdir(same_dir.c_str(), 0755) == 0) {
+                    mkdir_success.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    mkdir_failure.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+        }
+        for (auto &worker : workers) {
+            worker.join();
+        }
+        // TC-DIR-008 并发创建同名目录: 只有一个线程成功，其余线程失败。
+        EXPECT_EQ(mkdir_success.load(), 1);
+        EXPECT_EQ(mkdir_failure.load(), kThreads - 1);
+
+        std::atomic<int> create_success(0);
+        std::atomic<int> create_failure(0);
+        workers.clear();
+        for (int i = 0; i < kThreads; ++i) {
+            workers.emplace_back([&]() {
+                if (dfs_create(same_file.c_str(), 0644) == 0) {
+                    create_success.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    create_failure.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+        }
+        for (auto &worker : workers) {
+            worker.join();
+        }
+        // TC-FILE-007 并发创建同名文件: 只有一个线程成功，其余线程失败。
+        EXPECT_EQ(create_success.load(), 1);
+        EXPECT_EQ(create_failure.load(), kThreads - 1);
+
+        EXPECT_EQ(dfs_unlink(same_file.c_str()), 0);
+        same_file.clear();
+        EXPECT_EQ(dfs_rmdir(same_dir.c_str()), 0);
+        same_dir.clear();
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+    } catch (...) {
+        ADD_FAILURE() << "concurrent directory/file create flow threw an exception";
+    }
+
+    if (!same_file.empty()) {
+        dfs_unlink(same_file.c_str());
+    }
+    if (!same_dir.empty()) {
+        dfs_rmdir(same_dir.c_str());
+    }
+    if (!namespace_removed) {
+        try {
+            UninitNamespaceRoot(root);
+        } catch (...) {
+        }
+    }
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, SliceIdConcurrentAndAllocatorIsolationFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-SLICE-002 并发 FETCH_SLICE_ID 不重叠:
+     *   并发 FETCH_SLICE_ID 返回的区间互不重叠;
+     * - TC-SLICE-003 FILE/KV 两类分配器隔离: FILE 和 KV 两类 slice-id 分配器都能通过
+     *   序列化元数据入口返回结果。
+     *
+     * 前半部分通过 DFS 客户端校验外部可见的分配行为。
+     * 后半部分分别用 type=0(KV) 和 type=1(FILE) 直接调用
+     * falcon_meta_call_by_serialized_data，同时覆盖 sliceid_table.c 中的关系选择分支。
+     */
+    if (!local_run_test::EnsureConfiguredServer()) {
+        GTEST_SKIP() << "local-run service is not configured";
+    }
+    if (!InitClientOrSkip()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    constexpr int kThreads = 8;
+    constexpr uint32_t kCountPerThread = 3;
+    std::vector<std::pair<uint64_t, uint64_t>> ranges(kThreads);
+    std::vector<int> ret_codes(kThreads, -1);
+    std::vector<std::thread> workers;
+    for (int i = 0; i < kThreads; ++i) {
+        workers.emplace_back([&, i]() {
+            uint64_t start = 0;
+            uint64_t end = 0;
+            ret_codes[i] = dfs_fetch_slice_id(kCountPerThread, &start, &end);
+            ranges[i] = {start, end};
+        });
+    }
+    for (auto &worker : workers) {
+        worker.join();
+    }
+
+    // TC-SLICE-002 并发 FETCH_SLICE_ID 不重叠: 每次分配数量正确。
+    for (int i = 0; i < kThreads; ++i) {
+        ASSERT_EQ(ret_codes[i], 0);
+        EXPECT_EQ(ranges[i].second - ranges[i].first, kCountPerThread);
+    }
+    std::sort(ranges.begin(), ranges.end());
+    // TC-SLICE-002 并发 FETCH_SLICE_ID 不重叠: 排序后相邻区间不重叠。
+    for (size_t i = 1; i < ranges.size(); ++i) {
+        EXPECT_LE(ranges[i - 1].second, ranges[i].first);
+    }
+
+    int worker_port = local_run_test::GetIntEnvOrDefault("LOCAL_RUN_WORKER_PG_PORT", 55520);
+    std::unique_ptr<PgConnection> worker_owner;
+    PgConnection *worker = nullptr;
+    if (!ConnectPlainSql(worker_port, worker, worker_owner)) {
+        dfs_shutdown();
+        GTEST_SKIP() << "worker PostgreSQL endpoint is not ready";
+    }
+
+    int response_size = 0;
+    // TC-SLICE-003 FILE/KV 两类分配器隔离: KV 分配器可以返回 slice-id。
+    EXPECT_TRUE(worker->SerializedCall(FETCH_SLICE_ID, BuildSliceIdParam(2, 0), &response_size))
+        << worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    // TC-SLICE-003 FILE/KV 两类分配器隔离: FILE 分配器可以返回 slice-id。
+    EXPECT_TRUE(worker->SerializedCall(FETCH_SLICE_ID, BuildSliceIdParam(2, 1), &response_size))
+        << worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, InvalidFilenameBoundaryFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-FILE-010 文件名超长/非法字符: 非法路径会被拒绝，且不会留下可见元数据项。
+     *
+     * 当前元数据层没有对普通路径组件强制 POSIX NAME_MAX 限制，
+     * 因此此处覆盖当前实现中稳定的边界: 空路径不能 create，也不能 stat。
+     */
+    if (!local_run_test::EnsureConfiguredServer()) {
+        GTEST_SKIP() << "local-run service is not configured";
+    }
+    if (!InitClientOrSkip()) {
+        GTEST_SKIP() << "local-run service is not ready";
+    }
+
+    struct stat stbuf;
+    // TC-FILE-010 文件名超长/非法字符: 空路径不能 create，也不能 stat。
+    EXPECT_NE(dfs_create("", 0644), 0);
+    EXPECT_NE(dfs_stat("", &stbuf), 0);
+    dfs_shutdown();
+}

--- a/tests/falcon/metadb/test_metadb_helper_ut.cpp
+++ b/tests/falcon/metadb/test_metadb_helper_ut.cpp
@@ -1,0 +1,268 @@
+#include "test_metadb_coverage_common.h"
+
+#include <algorithm>
+
+using namespace metadb_test;
+
+namespace {
+
+MetaProcessInfoData BuildSampleMetaInfo(char *name, char *dst_name)
+{
+    MetaProcessInfoData info{};
+    info.path = "/roundtrip";
+    info.parentId = 11;
+    info.parentId_partId = 22;
+    info.name = name;
+    info.inodeId = 33;
+    info.st_dev = 44;
+    info.st_mode = 0644;
+    info.st_nlink = 1;
+    info.st_uid = 1000;
+    info.st_gid = 1000;
+    info.st_rdev = 55;
+    info.st_size = 4096;
+    info.st_blksize = 4096;
+    info.st_blocks = 8;
+    info.st_atim = 101;
+    info.st_mtim = 102;
+    info.st_ctim = 103;
+    info.node_id = 7;
+    info.dstParentId = 66;
+    info.dstParentIdPartId = 0;
+    info.dstName = dst_name;
+    info.targetIsDirectory = false;
+    info.srcLockOrder = 1;
+    info.errorCode = SUCCESS;
+    return info;
+}
+
+}  // 匿名命名空间
+
+TEST(MetadbCoverageUT, SerializedMetaSubParamRoundTrip)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-001 创建一级目录成功、TC-DIR-006 删除空目录成功;
+     * - TC-FILE-001 CREATE 成功并可见、TC-FILE-006 UNLINK 删除后不可见;
+     * - TC-REN-001 同目录文件重命名成功。
+     *
+     * 该用例只覆盖 serialized 子操作参数的编码/解码，不依赖 local-run 服务。
+     */
+    char name[] = "child";
+    char dst_name[] = "dst";
+    MetaProcessInfoData info = BuildSampleMetaInfo(name, dst_name);
+    MetaProcessInfo info_ptrs[] = {&info};
+    std::vector<FalconMetaServiceType> sub_param_types = {
+        MKDIR_SUB_MKDIR,
+        MKDIR_SUB_CREATE,
+        RMDIR_SUB_RMDIR,
+        RMDIR_SUB_UNLINK,
+        RENAME_SUB_RENAME_LOCALLY,
+        RENAME_SUB_CREATE,
+    };
+    for (auto type : sub_param_types) {
+        SerializedDataGuard param;
+        MetaProcessInfoData decoded{};
+        // TC-DIR/TC-FILE/TC-REN: 子操作参数编码后应能被同类型解码。
+        ASSERT_TRUE(SerializedDataMetaParamEncodeWithPerProcessFlatBufferBuilder(type, info_ptrs, nullptr, 1, param.get()));
+        ASSERT_TRUE(SerializedDataMetaParamDecode(type, 1, param.get(), &decoded));
+    }
+}
+
+TEST(MetadbCoverageUT, SerializedMetaResponseEncodeFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR、TC-FILE、TC-REN、TC-ATTR 相关用例的 serialized 响应编码支撑覆盖。
+     *
+     * 该用例只验证常用元数据操作响应可以被编码。
+     */
+    char name[] = "child";
+    char dst_name[] = "dst";
+    MetaProcessInfoData info = BuildSampleMetaInfo(name, dst_name);
+
+    OneReadDirResult child{.fileName = "child", .mode = 0644};
+    OneReadDirResult *children[] = {&child};
+    info.readDirLastShardIndex = 2;
+    info.readDirLastFileName = "last";
+    info.readDirResultList = children;
+    info.readDirResultCount = 1;
+
+    std::vector<FalconMetaServiceType> response_types = {
+        MKDIR,
+        CREATE,
+        STAT,
+        OPEN,
+        CLOSE,
+        UNLINK,
+        READDIR,
+        OPENDIR,
+        RMDIR,
+        RENAME,
+        RENAME_SUB_RENAME_LOCALLY,
+        UTIMENS,
+        CHOWN,
+        CHMOD,
+    };
+    for (auto type : response_types) {
+        SerializedDataGuard response;
+        // TC-DIR/TC-FILE/TC-REN/TC-ATTR: 常用操作响应编码应成功。
+        ASSERT_TRUE(SerializedDataMetaResponseEncodeWithPerProcessFlatBufferBuilder(type, 1, &info, response.get()));
+    }
+}
+
+TEST(MetadbCoverageUT, SerializedMetaSubResponseRoundTripAndErrorFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-001、TC-DIR-006、TC-FILE-001、TC-FILE-006、TC-REN-001;
+     * - TC-REN-003 / TC-ATTR-004 的失败错误码解码。
+     *
+     * 该用例只覆盖子操作响应成功解码和错误码解码。
+     */
+    char name[] = "child";
+    char dst_name[] = "dst";
+    MetaProcessInfoData info = BuildSampleMetaInfo(name, dst_name);
+
+    std::vector<FalconMetaServiceType> response_decode_types = {
+        MKDIR_SUB_MKDIR,
+        MKDIR_SUB_CREATE,
+        RMDIR_SUB_RMDIR,
+        RMDIR_SUB_UNLINK,
+        RENAME_SUB_RENAME_LOCALLY,
+        RENAME_SUB_CREATE,
+    };
+    for (auto type : response_decode_types) {
+        SerializedDataGuard response;
+        MetaProcessInfoData decoded{};
+        // TC-DIR/TC-FILE/TC-REN: 子操作响应编码后应能解码出 SUCCESS。
+        ASSERT_TRUE(SerializedDataMetaResponseEncodeWithPerProcessFlatBufferBuilder(type, 1, &info, response.get()));
+        ASSERT_TRUE(SerializedDataMetaResponseDecode(type, 1, response.get(), &decoded));
+        EXPECT_EQ(decoded.errorCode, SUCCESS);
+    }
+
+    info.errorCode = FILE_NOT_EXISTS;
+    // TC-REN-003 / TC-ATTR-004: 覆盖元数据响应中的失败错误码解码。
+    SerializedDataGuard error_response;
+    MetaProcessInfoData decoded_error{};
+    ASSERT_TRUE(SerializedDataMetaResponseEncodeWithPerProcessFlatBufferBuilder(MKDIR_SUB_MKDIR, 1, &info, error_response.get()));
+    ASSERT_TRUE(SerializedDataMetaResponseDecode(MKDIR_SUB_MKDIR, 1, error_response.get(), &decoded_error));
+    EXPECT_EQ(decoded_error.errorCode, FILE_NOT_EXISTS);
+}
+
+TEST(MetadbCoverageUT, SerializedKvResponseEncodeFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-KV-001 KV_PUT 新 key 成功;
+     * - TC-KV-002 KV_GET 命中返回一致;
+     * - TC-KV-003 KV_DEL 删除后不可读。
+     *
+     * 该用例只覆盖 KV serialized 响应编码。
+     */
+    uint64_t value_keys[] = {101, 102};
+    uint64_t locations[] = {201, 202};
+    uint32_t slice_lens[] = {301, 302};
+    KvMetaProcessInfoData kv_info{};
+    kv_info.errorCode = SUCCESS;
+    kv_info.valuelen = 603;
+    kv_info.slicenum = 2;
+    kv_info.valuekey = value_keys;
+    kv_info.location = locations;
+    kv_info.slicelen = slice_lens;
+    for (auto type : {KV_PUT, KV_GET, KV_DEL}) {
+        SerializedDataGuard response;
+        // TC-KV-001/002/003: KV put/get/del 响应编码应成功。
+        ASSERT_TRUE(SerializedKvMetaResponseEncodeWithPerProcessFlatBufferBuilder(type, 1, &kv_info, response.get()));
+    }
+}
+
+TEST(MetadbCoverageUT, SerializedSliceResponseEncodeFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-SLICE-004 SLICE_PUT 后 GET 一致;
+     * - TC-SLICE-005 SLICE_DEL 删除后 GET 失败。
+     *
+     * 该用例只覆盖 slice put/get/delete 的 serialized 响应编码。
+     */
+    uint64_t inode_ids[] = {301, 302};
+    uint32_t chunk_ids[] = {1, 2};
+    uint64_t slice_ids[] = {401, 402};
+    uint32_t slice_sizes[] = {4096, 8192};
+    uint32_t slice_offsets[] = {0, 4096};
+    uint32_t slice_lengths[] = {4096, 4096};
+    uint32_t slice_loc1s[] = {7, 8};
+    uint32_t slice_loc2s[] = {9, 10};
+    SliceProcessInfoData slice_info{};
+    slice_info.errorCode = SUCCESS;
+    slice_info.count = 2;
+    slice_info.inodeIds = inode_ids;
+    slice_info.chunkIds = chunk_ids;
+    slice_info.sliceIds = slice_ids;
+    slice_info.sliceSizes = slice_sizes;
+    slice_info.sliceOffsets = slice_offsets;
+    slice_info.sliceLens = slice_lengths;
+    slice_info.sliceLoc1s = slice_loc1s;
+    slice_info.sliceloc2s = slice_loc2s;
+    for (auto type : {SLICE_PUT, SLICE_GET, SLICE_DEL}) {
+        SerializedDataGuard response;
+        // TC-SLICE-004/005: slice put/get/del 响应编码应成功。
+        ASSERT_TRUE(SerializedSliceResponseEncodeWithPerProcessFlatBufferBuilder(type, 1, &slice_info, response.get()));
+    }
+}
+
+TEST(MetadbCoverageUT, SerializedSliceIdResponseEncodeFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-SLICE-001 单线程 FETCH_SLICE_ID。
+     *
+     * 该用例只覆盖 slice-id 分配响应编码。
+     */
+    SliceIdProcessInfoData slice_id_info{};
+    slice_id_info.errorCode = SUCCESS;
+    slice_id_info.start = 500;
+    slice_id_info.end = 502;
+    SerializedDataGuard slice_id_response;
+    // TC-SLICE-001: slice-id 响应编码应成功。
+    ASSERT_TRUE(SerializedSliceIdResponseEncodeWithPerProcessFlatBufferBuilder(&slice_id_info, slice_id_response.get()));
+}
+
+TEST(MetadbCoverageUT, MetaProcessInfoPathComparatorFlow)
+{
+    /*
+     * DT 支撑覆盖:
+     * - 支撑 TC-REN-001 同目录文件重命名成功 和 TC-REN-002 跨目录重命名成功。
+     * - 覆盖 metadb 在 rename 等多对象元数据操作前，对每个路径的 process info
+     *   排序时使用的路径比较辅助函数。
+     *
+     * 这是一个不依赖服务的单元测试:
+     * 1. 构造父路径、子路径和兄弟路径的 MetaProcessInfo 记录;
+     * 2. 分别按两个方向直接调用 pg_qsort_meta_process_info_by_path_cmp;
+     * 3. 对 MetaProcessInfo 指针数组排序，并验证父路径排在子路径前面。
+     */
+    MetaProcessInfoData parent{};
+    MetaProcessInfoData child{};
+    MetaProcessInfoData sibling{};
+    parent.path = "/metadb/path";
+    child.path = "/metadb/path/child";
+    sibling.path = "/metadb/sibling";
+
+    MetaProcessInfo parent_ptr = &parent;
+    MetaProcessInfo child_ptr = &child;
+    MetaProcessInfo sibling_ptr = &sibling;
+    // TC-REN-001 / TC-REN-002: rename 前多路径加锁排序需要父路径排在子路径前。
+    EXPECT_LT(pg_qsort_meta_process_info_by_path_cmp(&parent_ptr, &child_ptr), 0);
+    EXPECT_GT(pg_qsort_meta_process_info_by_path_cmp(&child_ptr, &parent_ptr), 0);
+
+    std::vector<MetaProcessInfo> infos = {sibling_ptr, child_ptr, parent_ptr};
+    // TC-REN-001 / TC-REN-002: 验证排序结果满足父子路径顺序约束。
+    std::sort(infos.begin(), infos.end(), [](const MetaProcessInfo &lhs, const MetaProcessInfo &rhs) {
+        return pg_qsort_meta_process_info_by_path_cmp(&lhs, &rhs) < 0;
+    });
+    ASSERT_EQ(infos.size(), 3U);
+    EXPECT_STREQ(infos[0]->path, "/metadb/path");
+    EXPECT_STREQ(infos[1]->path, "/metadb/path/child");
+    EXPECT_STREQ(infos[2]->path, "/metadb/sibling");
+}

--- a/tests/falcon/metadb/test_metadb_sql_serialized_ut.cpp
+++ b/tests/falcon/metadb/test_metadb_sql_serialized_ut.cpp
@@ -1,0 +1,466 @@
+#include "test_metadb_coverage_common.h"
+
+using namespace metadb_test;
+
+namespace {
+
+struct SqlConnections {
+    std::unique_ptr<PgConnection> cn_owner;
+    std::unique_ptr<PgConnection> worker_owner;
+    PgConnection *cn = nullptr;
+    PgConnection *worker = nullptr;
+};
+
+bool PrepareSqlConnections(SqlConnections *connections)
+{
+    constexpr int kRetry = 2;
+    for (int attempt = 0; attempt < kRetry; ++attempt) {
+        if (!local_run_test::EnsureConfiguredServer()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+        if (!InitClientOrSkip()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        int cn_port = local_run_test::GetIntEnvOrDefault("LOCAL_RUN_PG_PORT", 55500);
+        int worker_port = local_run_test::GetIntEnvOrDefault("LOCAL_RUN_WORKER_PG_PORT", 55520);
+        if (!ConnectPlainSql(cn_port, connections->cn, connections->cn_owner) ||
+            !ConnectPlainSql(worker_port, connections->worker, connections->worker_owner)) {
+            dfs_shutdown();
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
+std::string BuildSqlRoot(const char *tag)
+{
+    std::string root = BuildRootPath(tag);
+    if (root.size() > 1 && root.back() == '/') {
+        root.pop_back();
+    }
+    return root;
+}
+
+}  // 匿名命名空间
+
+TEST(MetadbCoverageUT, PlainSqlDirectoryLifecycleFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-001 创建一级目录成功;
+     * - TC-DIR-002 重复创建同名目录失败;
+     * - TC-DIR-006 删除空目录成功。
+     *
+     * 该用例只覆盖 plain SQL 目录 mkdir/rmdir 生命周期。
+     */
+    SqlConnections connections;
+    if (!PrepareSqlConnections(&connections)) {
+        GTEST_SKIP() << "local-run SQL endpoints are not ready";
+    }
+
+    std::string root = BuildSqlRoot("plain_sql_dir");
+    int ret = -1;
+    bool namespace_removed = false;
+    // TC-DIR-001: CN plain SQL 创建根目录。
+    ASSERT_TRUE(connections.cn->ScalarInt("SELECT falcon_plain_mkdir(" + SqlQuote(root) + ")", &ret))
+        << connections.cn->ErrorMessage();
+    EXPECT_EQ(ret, 0);
+    // TC-DIR-002: 第二次 mkdir 返回失败码。
+    EXPECT_TRUE(connections.cn->ScalarInt("SELECT falcon_plain_mkdir(" + SqlQuote(root) + ")", &ret));
+    EXPECT_NE(ret, 0);
+    // TC-DIR-006: 删除空目录成功。
+    EXPECT_TRUE(connections.cn->ScalarInt("SELECT falcon_plain_rmdir(" + SqlQuote(root) + ")", &ret));
+    EXPECT_EQ(ret, 0);
+    namespace_removed = true;
+
+    if (!namespace_removed) {
+        dfs_rmdir(root.c_str());
+    }
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, PlainSqlFileCreateStatAndReadDirFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-FILE-001 CREATE 成功并可见;
+     * - TC-DIR-005 READDIR 返回目录项完整;
+     * - TC-FILE-003 父路径不存在 CREATE/STAT 失败相关反向校验;
+     * - TC-FILE-006 UNLINK 删除后不可见。
+     *
+     * 该用例只覆盖 plain SQL 文件创建、stat、readdir 和删除。
+     */
+    SqlConnections connections;
+    if (!PrepareSqlConnections(&connections)) {
+        GTEST_SKIP() << "local-run SQL endpoints are not ready";
+    }
+
+    std::string root = BuildSqlRoot("plain_sql_file");
+    std::string file = fmt::format("{}/plain_file", root);
+    int ret = -1;
+    bool namespace_removed = false;
+    // TC-DIR-001: 先创建承载文件的根目录。
+    ASSERT_TRUE(connections.cn->ScalarInt("SELECT falcon_plain_mkdir(" + SqlQuote(root) + ")", &ret))
+        << connections.cn->ErrorMessage();
+    ASSERT_EQ(ret, 0);
+
+    // TC-FILE-001: worker plain SQL 创建文件并通过 stat 校验。
+    EXPECT_TRUE(connections.worker->ScalarInt("SELECT falcon_plain_create(" + SqlQuote(file) + ")", &ret));
+    EXPECT_EQ(ret, 0);
+    EXPECT_TRUE(connections.worker->ScalarInt("SELECT falcon_plain_stat(" + SqlQuote(file) + ")", &ret));
+    EXPECT_EQ(ret, 0);
+
+    // TC-DIR-005: readdir 能看到新建文件。
+    std::string entries;
+    EXPECT_TRUE(connections.worker->ScalarText("SELECT falcon_plain_readdir(" + SqlQuote(root) + ")", &entries));
+    EXPECT_NE(entries.find("plain_file"), std::string::npos);
+
+    // TC-FILE-003: 不存在文件 stat 返回失败码。
+    std::string missing = fmt::format("{}/missing", root);
+    EXPECT_TRUE(connections.worker->ScalarInt("SELECT falcon_plain_stat(" + SqlQuote(missing) + ")", &ret));
+    EXPECT_NE(ret, 0);
+
+    // TC-FILE-006 / TC-DIR-006: 清理文件和根目录。
+    EXPECT_EQ(dfs_unlink(file.c_str()), 0);
+    EXPECT_TRUE(connections.cn->ScalarInt("SELECT falcon_plain_rmdir(" + SqlQuote(root) + ")", &ret));
+    EXPECT_EQ(ret, 0);
+    namespace_removed = true;
+
+    if (!namespace_removed) {
+        dfs_unlink(file.c_str());
+        dfs_rmdir(root.c_str());
+    }
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, AdminSqlCacheAndShardFlow)
+{
+    /*
+     * DT 对应关系:
+     * - falconfs_metadata_DT_test_cases_zh.md 中没有一对一的直接用例。
+     * - 该用例通过校验 foreign-server cache reload 和 shard-table cache 维护，
+     *   支撑文档中“服务侧元数据路由可用”的通用前置条件。
+     *
+     * 该流程覆盖 metadb 管理类 SQL 函数:
+     * 1. 重新加载 foreign-server cache;
+     * 2. 运行 foreign-server 测试钩子，获取连接/信息数据并完成清理;
+     * 3. 插入一个临时 foreign server，更新后重新加载 cache，再删除该记录;
+     * 4. 重新生成并加载 shard-table cache;
+     * 5. 使用当前最大 range point/server 映射调用 falcon_update_shard_table。
+     *
+     * 退出前会删除临时 foreign server。shard 更新保持当前有效映射不变，
+     * 因此不会改变 local-run 服务拓扑。
+     */
+    constexpr int kFlowRetry = 2;
+    for (int attempt = 0; attempt < kFlowRetry; ++attempt) {
+        if (!local_run_test::EnsureConfiguredServer()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        int cn_port = local_run_test::GetIntEnvOrDefault("LOCAL_RUN_PG_PORT", 55500);
+        std::unique_ptr<PgConnection> cn_owner;
+        PgConnection *cn = nullptr;
+        if (!ConnectPlainSql(cn_port, cn, cn_owner)) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        int ret = -1;
+        int count = 0;
+        int dummy_id = 9000 + static_cast<int>(getpid() % 1000);
+        bool inserted = false;
+        bool success = false;
+        try {
+            // 通用前置条件: foreign-server cache 可以重新加载。
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_reload_foreign_server_cache()", &ret)) << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+            // 通用前置条件: foreign-server 连接信息测试钩子可以正常执行并清理。
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_foreign_server_test('GET_INFO_CONN_AND_CLEANUP')", &ret))
+                << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+
+            // 通用前置条件: foreign server 记录可以插入、更新、重载 cache 后删除。
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_insert_foreign_server(" + std::to_string(dummy_id) +
+                                          ", 'metadb_admin_dummy', '127.0.0.1', 55990, false, current_user::cstring)",
+                                      &ret))
+                << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+            inserted = true;
+
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_update_foreign_server(" + std::to_string(dummy_id) +
+                                          ", '127.0.0.2', 55991)",
+                                      &ret))
+                << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_reload_foreign_server_cache()", &ret)) << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+
+            // 通用前置条件: shard-table cache 可以重新生成并重新加载。
+            EXPECT_TRUE(cn->ScalarInt("SELECT count(*) FROM falcon_renew_shard_table()", &count))
+                << cn->ErrorMessage();
+            EXPECT_GT(count, 0);
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_reload_shard_table_cache()", &ret)) << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+            // 通用前置条件: shard table 更新接口在保持当前映射不变时可正常返回。
+            EXPECT_TRUE(cn->ScalarInt(
+                            "SELECT falcon_update_shard_table("
+                            "ARRAY[(SELECT max(range_point)::bigint FROM falcon_shard_table)], "
+                            "ARRAY[(SELECT server_id FROM falcon_shard_table ORDER BY range_point DESC LIMIT 1)])",
+                            &ret))
+                << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+
+            EXPECT_TRUE(cn->ScalarInt("SELECT falcon_delete_foreign_server(" + std::to_string(dummy_id) + ")", &ret))
+                << cn->ErrorMessage();
+            EXPECT_EQ(ret, 0);
+            inserted = false;
+            success = true;
+        } catch (...) {
+        }
+
+        if (inserted) {
+            cn->ScalarInt("SELECT falcon_delete_foreign_server(" + std::to_string(dummy_id) + ")", &ret);
+        }
+        if (success && !HasFailure()) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+
+    GTEST_SKIP() << "metadb admin SQL flow failed after retries, likely due unstable service state";
+}
+
+
+TEST(MetadbCoverageUT, SerializedDirectoryFileAttributeFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-DIR-001 创建一级目录成功 / TC-DIR-005 READDIR 返回目录项完整 /
+     *   TC-DIR-006 删除空目录成功;
+     * - TC-FILE-001 CREATE 成功并可见 / TC-FILE-005 OPEN/CLOSE 生命周期 /
+     *   TC-FILE-006 UNLINK 删除后不可见;
+     * - TC-ATTR-001 UTIMENS 更新并校验 / TC-ATTR-002 CHMOD 更新并校验 /
+     *   TC-ATTR-003 CHOWN 更新并校验。
+     *
+     * 该用例只覆盖 serialized 入口的目录、文件和属性基础生命周期。
+     */
+    SqlConnections connections;
+    if (!PrepareSqlConnections(&connections)) {
+        GTEST_SKIP() << "local-run SQL endpoints are not ready";
+    }
+
+    std::string root = BuildSqlRoot("serialized_dir_file_attr");
+    std::string file = fmt::format("{}/serialized_file", root);
+    int response_size = 0;
+    bool namespace_removed = false;
+
+    // TC-DIR-001: serialized 入口创建根目录。
+    ASSERT_TRUE(connections.cn->SerializedCall(MKDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.cn->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    // TC-FILE-001: serialized 入口创建文件并 stat。
+    EXPECT_TRUE(connections.worker->SerializedCall(CREATE, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(STAT, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    // TC-FILE-005: open 后 close 成功。
+    EXPECT_TRUE(connections.worker->SerializedCall(OPEN, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(CLOSE,
+                                                   BuildCloseParam(file, 8192, 1640995200000000000ULL, 0),
+                                                   &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    // TC-ATTR-001/003/002: serialized 入口分别覆盖 utimens、chown、chmod。
+    EXPECT_TRUE(connections.worker->SerializedCall(UTIMENS,
+                                                   BuildUtimeNsParam(file, 1609459200000000000ULL,
+                                                                     1640995200000000000ULL),
+                                                   &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_TRUE(connections.worker->SerializedCall(CHOWN,
+                                                   BuildChownParam(file, static_cast<uint32_t>(getuid()),
+                                                                   static_cast<uint32_t>(getgid())),
+                                                   &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_TRUE(connections.worker->SerializedCall(CHMOD, BuildChmodParam(file, 0600), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    // TC-DIR-005: serialized 入口覆盖 opendir/readdir。
+    EXPECT_TRUE(connections.worker->SerializedCall(OPENDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_TRUE(connections.worker->SerializedCall(READDIR, BuildReadDirParam(root, 1, -1, ""), &response_size))
+        << connections.worker->ErrorMessage();
+
+    // TC-FILE-006 / TC-DIR-006: serialized 入口清理文件和目录。
+    EXPECT_TRUE(connections.worker->SerializedCall(UNLINK, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_TRUE(connections.cn->SerializedCall(RMDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.cn->ErrorMessage();
+    namespace_removed = true;
+
+    if (!namespace_removed) {
+        dfs_unlink(file.c_str());
+        dfs_rmdir(root.c_str());
+    }
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, SerializedRenameFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-REN-001 同目录文件重命名成功;
+     * - TC-FILE-006 UNLINK 删除后不可见;
+     * - TC-DIR-006 删除空目录成功。
+     *
+     * 该用例只覆盖 serialized 入口的 rename 成功路径。
+     */
+    SqlConnections connections;
+    if (!PrepareSqlConnections(&connections)) {
+        GTEST_SKIP() << "local-run SQL endpoints are not ready";
+    }
+
+    std::string root = BuildSqlRoot("serialized_rename");
+    std::string file = fmt::format("{}/serialized_file", root);
+    std::string renamed = fmt::format("{}/serialized_file_renamed", root);
+    int response_size = 0;
+    bool namespace_removed = false;
+
+    ASSERT_TRUE(connections.cn->SerializedCall(MKDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.cn->ErrorMessage();
+    ASSERT_TRUE(connections.worker->SerializedCall(CREATE, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+    // TC-REN-001: serialized rename 后新路径 stat 成功。
+    EXPECT_TRUE(connections.cn->SerializedCall(RENAME, BuildRenameParam(file, renamed), &response_size))
+        << connections.cn->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(STAT, BuildPathOnlyParam(renamed), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+
+    EXPECT_TRUE(connections.worker->SerializedCall(UNLINK, BuildPathOnlyParam(renamed), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_TRUE(connections.cn->SerializedCall(RMDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.cn->ErrorMessage();
+    namespace_removed = true;
+
+    if (!namespace_removed) {
+        dfs_unlink(renamed.c_str());
+        dfs_unlink(file.c_str());
+        dfs_rmdir(root.c_str());
+    }
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, SerializedKvFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-KV-001 KV_PUT 新 key 成功;
+     * - TC-KV-002 KV_GET 命中返回一致;
+     * - TC-KV-003 KV_DEL 删除后不可读。
+     *
+     * 该用例只覆盖 serialized 入口的 KV put/get/delete。
+     */
+    SqlConnections connections;
+    if (!PrepareSqlConnections(&connections)) {
+        GTEST_SKIP() << "local-run SQL endpoints are not ready";
+    }
+
+    std::string key = BuildSqlRoot("serialized_kv");
+    int response_size = 0;
+    std::vector<uint64_t> value_key = {11, 12};
+    std::vector<uint64_t> location = {21, 22};
+    std::vector<uint32_t> size = {31, 32};
+
+    // TC-KV-001/002/003: serialized 入口覆盖 KV put/get/delete。
+    EXPECT_TRUE(connections.worker->SerializedCall(KV_PUT, BuildKvParam(key, 8192, value_key, location, size),
+                                                   &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(KV_GET, BuildKeyOnlyParam(key), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(KV_DEL, BuildKeyOnlyParam(key), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    dfs_shutdown();
+}
+
+TEST(MetadbCoverageUT, SerializedSliceFlow)
+{
+    /*
+     * DT 对应关系:
+     * - TC-SLICE-001 单线程 FETCH_SLICE_ID;
+     * - TC-SLICE-004 SLICE_PUT 后 GET 一致;
+     * - TC-SLICE-005 SLICE_DEL 删除后 GET 失败。
+     *
+     * 该用例只覆盖 serialized 入口的 slice-id 和 slice put/get/delete。
+     */
+    SqlConnections connections;
+    if (!PrepareSqlConnections(&connections)) {
+        GTEST_SKIP() << "local-run SQL endpoints are not ready";
+    }
+
+    std::string root = BuildSqlRoot("serialized_slice");
+    std::string file = fmt::format("{}/serialized_file", root);
+    int response_size = 0;
+    bool namespace_removed = false;
+
+    ASSERT_TRUE(connections.cn->SerializedCall(MKDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.cn->ErrorMessage();
+    ASSERT_TRUE(connections.worker->SerializedCall(CREATE, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+
+    struct stat stbuf;
+    ASSERT_EQ(dfs_stat(file.c_str(), &stbuf), 0);
+    uint64_t inode_id = static_cast<uint64_t>(stbuf.st_ino);
+    // TC-SLICE-001: serialized 入口分配 slice-id。
+    EXPECT_TRUE(connections.worker->SerializedCall(FETCH_SLICE_ID, BuildSliceIdParam(2, 1), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+
+    std::vector<uint64_t> inode_ids = {inode_id, inode_id};
+    std::vector<uint32_t> chunk_ids = {7, 7};
+    std::vector<uint64_t> slice_ids = {101, 102};
+    std::vector<uint32_t> slice_sizes = {4096, 4096};
+    std::vector<uint32_t> slice_offsets = {0, 4096};
+    std::vector<uint32_t> slice_lens = {4096, 4096};
+    std::vector<uint32_t> slice_loc1 = {1, 2};
+    std::vector<uint32_t> slice_loc2 = {3, 4};
+    // TC-SLICE-004/005: serialized 入口覆盖 slice put/get/delete。
+    EXPECT_TRUE(connections.worker->SerializedCall(SLICE_PUT,
+                                                   BuildSliceInfoParam(file, inode_ids, chunk_ids, slice_ids,
+                                                                       slice_sizes, slice_offsets, slice_lens,
+                                                                       slice_loc1, slice_loc2),
+                                                   &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(SLICE_GET, BuildSliceIndexParam(file, inode_id, 7), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+    EXPECT_TRUE(connections.worker->SerializedCall(SLICE_DEL, BuildSliceIndexParam(file, inode_id, 7), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_GT(response_size, 4);
+
+    EXPECT_TRUE(connections.worker->SerializedCall(UNLINK, BuildPathOnlyParam(file), &response_size))
+        << connections.worker->ErrorMessage();
+    EXPECT_TRUE(connections.cn->SerializedCall(RMDIR, BuildPathOnlyParam(root), &response_size))
+        << connections.cn->ErrorMessage();
+    namespace_removed = true;
+
+    if (!namespace_removed) {
+        dfs_unlink(file.c_str());
+        dfs_rmdir(root.c_str());
+    }
+    dfs_shutdown();
+}

--- a/tests/private-directory-test/dfs.h
+++ b/tests/private-directory-test/dfs.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 #include <errno.h>
 #include <fcntl.h>
@@ -47,6 +49,12 @@ int dfs_write(int fd, const void *buf, size_t count, off_t offset);
 int dfs_close(int fd, const char* path = nullptr);
 int dfs_mkdir(const char *path, mode_t mode);
 int dfs_rmdir(const char *path);
+int dfs_opendir(const char *path, uint64_t *inode_id);
+int dfs_readdir(const char *path, std::vector<std::string> *entries);
+int dfs_rename(const char *src, const char *dst);
+int dfs_utimens(const char *path, int64_t atime, int64_t mtime);
+int dfs_chown(const char *path, uint32_t uid, uint32_t gid);
+int dfs_chmod(const char *path, uint32_t mode);
 int dfs_create(const char *path, mode_t mode);
 int dfs_unlink(const char *path);
 int dfs_stat(const char *path, struct stat *stbuf);

--- a/tests/private-directory-test/falconfs.cc
+++ b/tests/private-directory-test/falconfs.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <atomic>
+#include <unordered_map>
 
 using namespace std;
 
@@ -94,16 +95,126 @@ int dfs_mkdir(const char *path, mode_t mode)
 }
 int dfs_rmdir(const char *path)
 {
+    std::string dirPath(path);
+    if (dirPath.length() > 1 && dirPath.back() == '/') {
+        dirPath.pop_back();
+    }
+
     uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
     std::shared_ptr<Connection> conn = routers[index]->GetCoordinatorConn();
     if (!conn) {
         std::cout << "route error.\n";
         return PROGRAM_ERROR;
     }
-    int errorCode = conn->Rmdir(path);
+    int errorCode = conn->Rmdir(dirPath.c_str());
 
     return errorCode;
 }
+
+int dfs_opendir(const char *path, uint64_t *inode_id)
+{
+    std::string dirPath(path);
+    if (dirPath.length() > 1 && dirPath.back() == '/') {
+        dirPath.pop_back();
+    }
+
+    uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
+    std::shared_ptr<Connection> conn = routers[index]->GetCoordinatorConn();
+    if (!conn) {
+        std::cout << "route error.\n";
+        return PROGRAM_ERROR;
+    }
+
+    uint64_t inodeId = 0;
+    int errorCode = conn->OpenDir(dirPath.c_str(), inodeId);
+    if (errorCode == 0 && inode_id) {
+        *inode_id = inodeId;
+    }
+    return errorCode;
+}
+
+int dfs_readdir(const char *path, std::vector<std::string> *entries)
+{
+    uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
+    std::unordered_map<std::string, std::shared_ptr<Connection>> workerInfo;
+    int errorCode = routers[index]->GetAllWorkerConnection(workerInfo);
+    if (errorCode != 0) {
+        return errorCode;
+    }
+
+    for (const auto &worker : workerInfo) {
+        int32_t lastShardIndex = -1;
+        std::string lastFileName;
+        bool finished = false;
+        while (!finished) {
+            Connection::ReadDirResponse response;
+            errorCode = worker.second->ReadDir(path,
+                                               response,
+                                               128,
+                                               lastShardIndex,
+                                               lastFileName.empty() ? nullptr : lastFileName.c_str());
+            if (errorCode != 0) {
+                return errorCode;
+            }
+
+            lastShardIndex = response.response->last_shard_index();
+            lastFileName = response.response->last_file_name() ? response.response->last_file_name()->str() : "";
+            auto resultList = response.response->result_list();
+            if (entries && resultList) {
+                for (uint32_t i = 0; i < resultList->size(); ++i) {
+                    entries->push_back(resultList->Get(i)->file_name()->str());
+                }
+            }
+            finished = resultList == nullptr || resultList->size() < 128;
+        }
+    }
+    return 0;
+}
+
+int dfs_rename(const char *src, const char *dst)
+{
+    uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
+    std::shared_ptr<Connection> conn = routers[index]->GetCoordinatorConn();
+    if (!conn) {
+        std::cout << "route error.\n";
+        return PROGRAM_ERROR;
+    }
+    return conn->Rename(src, dst);
+}
+
+int dfs_utimens(const char *path, int64_t atime, int64_t mtime)
+{
+    uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
+    std::shared_ptr<Connection> conn = routers[index]->GetWorkerConnByPath(std::string(path));
+    if (!conn) {
+        std::cout << "route error.\n";
+        return PROGRAM_ERROR;
+    }
+    return conn->UtimeNs(path, atime, mtime);
+}
+
+int dfs_chown(const char *path, uint32_t uid, uint32_t gid)
+{
+    uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
+    std::shared_ptr<Connection> conn = routers[index]->GetWorkerConnByPath(std::string(path));
+    if (!conn) {
+        std::cout << "route error.\n";
+        return PROGRAM_ERROR;
+    }
+    return conn->Chown(path, uid, gid);
+}
+
+int dfs_chmod(const char *path, uint32_t mode)
+{
+    uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;
+    std::shared_ptr<Connection> conn = routers[index]->GetWorkerConnByPath(std::string(path));
+    if (!conn) {
+        std::cout << "route error.\n";
+        return PROGRAM_ERROR;
+    }
+    return conn->Chmod(path, mode);
+}
+
 int dfs_create(const char *path, mode_t mode)
 {
     uint64_t index = routerIndex.fetch_add(1, std::memory_order_relaxed) % s_clientNumber;

--- a/tests/private-directory-test/local_run_workload_test_common.h
+++ b/tests/private-directory-test/local_run_workload_test_common.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "dfs.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+namespace local_run_test {
+
+struct LocalRunParameters {
+    std::string mount_dir = "/";
+    int client_id = 0;
+    int mount_per_client = 1;
+    int wait_port = 1111;
+    int client_num = 1;
+};
+
+inline std::string GetEnvOrDefault(const char *key, const char *fallback)
+{
+    const char *value = std::getenv(key);
+    return value != nullptr ? std::string(value) : std::string(fallback);
+}
+
+inline int GetIntEnvOrDefault(const char *key, int fallback)
+{
+    const char *value = std::getenv(key);
+    if (value == nullptr || *value == '\0') {
+        return fallback;
+    }
+    return std::atoi(value);
+}
+
+inline bool IsEndpointReachable(const std::string &ip, int port)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return false;
+    }
+
+    sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(port));
+    if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {
+        close(fd);
+        return false;
+    }
+
+    bool reachable = (connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0);
+    close(fd);
+    return reachable;
+}
+
+inline bool WaitForEndpoint(const std::string &ip, int port, int retry_count = 6)
+{
+    for (int i = 0; i < retry_count; ++i) {
+        if (IsEndpointReachable(ip, port)) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    return false;
+}
+
+inline bool EnsureConfiguredServer()
+{
+    std::string ip = GetEnvOrDefault("SERVER_IP", "127.0.0.1");
+    int port = GetIntEnvOrDefault("SERVER_PORT", 55500);
+    return WaitForEndpoint(ip, port);
+}
+
+inline void ResetCounters()
+{
+    std::memset((void *)op_count, 0, sizeof(op_count));
+    std::memset((void *)latency_count, 0, sizeof(latency_count));
+}
+
+inline LocalRunParameters LoadLocalRunParameters()
+{
+    LocalRunParameters params;
+    params.mount_dir = GetEnvOrDefault("LOCAL_RUN_MOUNT_DIR", "/");
+    if (params.mount_dir.empty()) {
+        params.mount_dir = "/";
+    }
+    if (params.mount_dir.back() != '/') {
+        params.mount_dir.push_back('/');
+    }
+
+    files_per_dir = GetIntEnvOrDefault("LOCAL_RUN_FILE_PER_THREAD", 1);
+    int thread_num_per_client = GetIntEnvOrDefault("LOCAL_RUN_THREAD_NUM_PER_CLIENT", 1);
+    params.client_num = GetIntEnvOrDefault("LOCAL_RUN_CLIENT_NUM", 1);
+    if (thread_num_per_client < 1) {
+        thread_num_per_client = 1;
+    }
+    if (params.client_num < 1) {
+        params.client_num = 1;
+    }
+    thread_num = thread_num_per_client * params.client_num;
+
+    params.client_id = GetIntEnvOrDefault("LOCAL_RUN_CLIENT_ID", 0);
+    params.mount_per_client = GetIntEnvOrDefault("LOCAL_RUN_MOUNT_PER_CLIENT", 1);
+    params.wait_port = GetIntEnvOrDefault("LOCAL_RUN_WAIT_PORT", 1111);
+    client_cache_size = GetIntEnvOrDefault("LOCAL_RUN_CLIENT_CACHE_SIZE", 16384);
+    file_size = GetIntEnvOrDefault("LOCAL_RUN_FILE_SIZE", 4096);
+
+    if (files_per_dir < 1) {
+        files_per_dir = 1;
+    }
+    if (params.mount_per_client < 1) {
+        params.mount_per_client = 1;
+    }
+    if (client_cache_size < 1) {
+        client_cache_size = 1;
+    }
+    if (file_size < 1) {
+        file_size = 4096;
+    }
+
+    file_num = thread_num * files_per_dir;
+    return params;
+}
+
+}  // namespace local_run_test

--- a/tests/private-directory-test/test_local_run_posix_workload_ut.cpp
+++ b/tests/private-directory-test/test_local_run_posix_workload_ut.cpp
@@ -3,12 +3,10 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
-#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <string>
-#include <thread>
 
 int thread_num = 1;
 int client_cache_size = 16384;
@@ -86,6 +84,71 @@ std::string BuildRootPath()
     return fmt::format("{}posix_flow_{}_{}_{}/", client_root, getpid(), seq, time(nullptr));
 }
 
+std::string ThreadDir(const std::string &root, int thread_id)
+{
+    return fmt::format("{}thread_{}", root, thread_id);
+}
+
+std::string FilePath(const std::string &root, int thread_id, int file_id)
+{
+    return fmt::format("{}/file_{}", ThreadDir(root, thread_id), file_id);
+}
+
+std::string DirPath(const std::string &root, int thread_id, int dir_id)
+{
+    return fmt::format("{}/dir_{}", ThreadDir(root, thread_id), dir_id);
+}
+
+void InitNamespaceRoot(const std::string &root)
+{
+    int saved_files_per_dir = files_per_dir;
+    files_per_dir = 1 + thread_num;
+    workload_init(root, 0);
+    files_per_dir = saved_files_per_dir;
+}
+
+void UninitNamespaceRoot(const std::string &root)
+{
+    int saved_files_per_dir = files_per_dir;
+    files_per_dir = 1 + thread_num;
+    workload_uninit(root, 0);
+    files_per_dir = saved_files_per_dir;
+}
+
+void RunForEachThread(void (*workload)(std::string, int), const std::string &root)
+{
+    for (int thread_id = 0; thread_id < thread_num; ++thread_id) {
+        workload(root, thread_id);
+    }
+}
+
+void ExpectThreadFilesExist(const std::string &root, int thread_id)
+{
+    for (int file_id = 0; file_id < files_per_dir; ++file_id) {
+        struct stat stbuf;
+        SCOPED_TRACE(FilePath(root, thread_id, file_id));
+        EXPECT_EQ(dfs_stat(FilePath(root, thread_id, file_id).c_str(), &stbuf), 0);
+    }
+}
+
+void ExpectFilesExist(const std::string &root)
+{
+    for (int thread_id = 0; thread_id < thread_num; ++thread_id) {
+        ExpectThreadFilesExist(root, thread_id);
+    }
+}
+
+void ExpectDirsExist(const std::string &root)
+{
+    for (int thread_id = 0; thread_id < thread_num; ++thread_id) {
+        for (int dir_id = 0; dir_id < files_per_dir; ++dir_id) {
+            struct stat stbuf;
+            SCOPED_TRACE(DirPath(root, thread_id, dir_id));
+            EXPECT_EQ(dfs_stat(DirPath(root, thread_id, dir_id).c_str(), &stbuf), 0);
+        }
+    }
+}
+
 bool InitClient()
 {
     LoadPosixParameters();
@@ -95,41 +158,20 @@ bool InitClient()
     return dfs_init(1) == 0;
 }
 
-void CleanupRoot(const std::string &root, bool with_files)
+void CleanupRoot(const std::string &root, bool with_files, bool all_threads)
 {
     try {
         if (with_files) {
-            workload_delete(root, 0);
+            if (all_threads) {
+                RunForEachThread(workload_delete, root);
+            } else {
+                workload_delete(root, 0);
+            }
         }
-        int thread_dir_count = files_per_dir > 1 ? files_per_dir - 1 : 1;
-        for (int i = 0; i < thread_dir_count; ++i) {
-            std::string thread_dir = fmt::format("{}thread_{}", root, i);
-            dfs_rmdir(thread_dir.c_str());
-        }
-        workload_uninit(root, 0);
+        UninitNamespaceRoot(root);
     } catch (...) {
     }
     dfs_shutdown();
-}
-
-void EnsureDirExistsWithRetry(const std::string &path)
-{
-    constexpr int kRetry = 20;
-    struct stat stbuf;
-    for (int i = 0; i < kRetry; ++i) {
-        int ret = dfs_mkdir(path.c_str(), 0777);
-        if (ret == 0 || errno == EEXIST || dfs_stat(path.c_str(), &stbuf) == 0) {
-            return;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-    throw std::runtime_error("failed to ensure directory exists");
-}
-
-void EnsureThreadDir(const std::string &root)
-{
-    EnsureDirExistsWithRetry(root);
-    EnsureDirExistsWithRetry(fmt::format("{}thread_0", root));
 }
 
 }  // namespace
@@ -144,12 +186,12 @@ TEST(LocalRunPosixWorkloadUT, InitCreateStatOpenCloseFlow)
     std::string root = BuildRootPath();
     uint64_t start = op_count[0];
     try {
-        workload_init(root, 0);
+        InitNamespaceRoot(root);
         uint64_t after_init = op_count[0];
-        EnsureThreadDir(root);
 
         workload_create(root, 0);
         uint64_t after_create = op_count[0];
+        ExpectThreadFilesExist(root, 0);
 
         workload_stat(root, 0);
         uint64_t after_stat = op_count[0];
@@ -165,12 +207,92 @@ TEST(LocalRunPosixWorkloadUT, InitCreateStatOpenCloseFlow)
         EXPECT_GT(after_open, after_stat);
         EXPECT_GT(op_count[0], after_open);
     } catch (...) {
-        CleanupRoot(root, true);
+        CleanupRoot(root, true, false);
         GTEST_SKIP() << "posix full workload flow failed";
         return;
     }
 
-    CleanupRoot(root, true);
+    CleanupRoot(root, true, false);
+}
+
+TEST(LocalRunPosixWorkloadUT, FullFileWorkloadFlow)
+{
+    if (!InitClient()) {
+        GTEST_SKIP() << "posix dfs_init failed";
+        return;
+    }
+
+    std::string root = BuildRootPath();
+    bool files_deleted = false;
+    bool namespace_removed = false;
+    try {
+        InitNamespaceRoot(root);
+        uint64_t after_init = op_count[0];
+
+        RunForEachThread(workload_create, root);
+        uint64_t after_create = op_count[0];
+        ExpectFilesExist(root);
+
+        RunForEachThread(workload_stat, root);
+        uint64_t after_stat = op_count[0];
+
+        RunForEachThread(workload_open, root);
+        uint64_t after_open = op_count[0];
+
+        RunForEachThread(workload_close, root);
+        uint64_t after_close = op_count[0];
+
+        RunForEachThread(workload_delete, root);
+        files_deleted = true;
+        uint64_t after_delete_initial = op_count[0];
+
+        RunForEachThread(workload_mkdir, root);
+        uint64_t after_mkdir = op_count[0];
+        ExpectDirsExist(root);
+
+        RunForEachThread(workload_rmdir, root);
+        uint64_t after_rmdir = op_count[0];
+
+        RunForEachThread(workload_open_write_close, root);
+        files_deleted = false;
+        uint64_t after_open_write_close = op_count[0];
+        ExpectFilesExist(root);
+
+        RunForEachThread(workload_open_write_close_nocreate, root);
+        uint64_t after_open_write_close_nocreate = op_count[0];
+
+        RunForEachThread(workload_open_read_close, root);
+        uint64_t after_open_read_close = op_count[0];
+
+        RunForEachThread(workload_delete, root);
+        files_deleted = true;
+        uint64_t after_delete_final = op_count[0];
+
+        UninitNamespaceRoot(root);
+        namespace_removed = true;
+        uint64_t after_uninit = op_count[0];
+
+        EXPECT_GT(after_init, 0U);
+        EXPECT_GT(after_create, after_init);
+        EXPECT_GT(after_stat, after_create);
+        EXPECT_GT(after_open, after_stat);
+        EXPECT_GT(after_close, after_open);
+        EXPECT_GT(after_delete_initial, after_close);
+        EXPECT_GT(after_mkdir, after_delete_initial);
+        EXPECT_GT(after_rmdir, after_mkdir);
+        EXPECT_GT(after_open_write_close, after_rmdir);
+        EXPECT_GT(after_open_write_close_nocreate, after_open_write_close);
+        EXPECT_GT(after_open_read_close, after_open_write_close_nocreate);
+        EXPECT_GT(after_delete_final, after_open_read_close);
+        EXPECT_GT(after_uninit, after_delete_final);
+    } catch (...) {
+    }
+
+    if (namespace_removed) {
+        dfs_shutdown();
+    } else {
+        CleanupRoot(root, !files_deleted, true);
+    }
 }
 
 int main(int argc, char **argv)

--- a/tests/private-directory-test/test_local_run_workload_ut.cpp
+++ b/tests/private-directory-test/test_local_run_workload_ut.cpp
@@ -1,15 +1,11 @@
 #include "dfs.h"
+#include "local_run_workload_test_common.h"
 
-#include <arpa/inet.h>
 #include <gtest/gtest.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <unistd.h>
 
 #include <atomic>
 #include <chrono>
-#include <cstdlib>
-#include <cstring>
 #include <string>
 #include <thread>
 
@@ -24,129 +20,110 @@ volatile uint64_t latency_count[16384];
 
 namespace {
 
-int g_client_id = 0;
-int g_mount_per_client = 1;
-int g_wait_port = 1111;
-int g_client_num = 1;
-std::string g_mount_dir = "/";
-
-std::string GetEnvOrDefault(const char *key, const char *fallback)
-{
-    const char *value = std::getenv(key);
-    return value != nullptr ? std::string(value) : std::string(fallback);
-}
-
-bool IsMetaServerReachable(const std::string &ip, int port)
-{
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        return false;
-    }
-
-    sockaddr_in addr;
-    std::memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(static_cast<uint16_t>(port));
-    if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {
-        close(fd);
-        return false;
-    }
-
-    bool reachable = (connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0);
-    close(fd);
-    return reachable;
-}
-
-bool EnsureServerOrSkip()
-{
-    std::string ip = GetEnvOrDefault("SERVER_IP", "127.0.0.1");
-    std::string port_text = GetEnvOrDefault("SERVER_PORT", "55500");
-    int port = std::atoi(port_text.c_str());
-
-    constexpr int kMaxRetry = 6;
-    for (int i = 0; i < kMaxRetry; ++i) {
-        if (IsMetaServerReachable(ip, port)) {
-            return true;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
-    return false;
-}
-
-int GetIntEnvOrDefault(const char *key, int fallback)
-{
-    const char *value = std::getenv(key);
-    if (value == nullptr || *value == '\0') {
-        return fallback;
-    }
-    return std::atoi(value);
-}
-
-void LoadLocalRunParameters()
-{
-    g_mount_dir = GetEnvOrDefault("LOCAL_RUN_MOUNT_DIR", "/");
-    if (g_mount_dir.empty()) {
-        g_mount_dir = "/";
-    }
-    if (g_mount_dir.back() != '/') {
-        g_mount_dir.push_back('/');
-    }
-
-    files_per_dir = GetIntEnvOrDefault("LOCAL_RUN_FILE_PER_THREAD", 1);
-    int thread_num_per_client = GetIntEnvOrDefault("LOCAL_RUN_THREAD_NUM_PER_CLIENT", 1);
-    g_client_num = GetIntEnvOrDefault("LOCAL_RUN_CLIENT_NUM", 1);
-    if (thread_num_per_client < 1) {
-        thread_num_per_client = 1;
-    }
-    if (g_client_num < 1) {
-        g_client_num = 1;
-    }
-    thread_num = thread_num_per_client * g_client_num;
-
-    g_client_id = GetIntEnvOrDefault("LOCAL_RUN_CLIENT_ID", 0);
-    g_mount_per_client = GetIntEnvOrDefault("LOCAL_RUN_MOUNT_PER_CLIENT", 1);
-    g_wait_port = GetIntEnvOrDefault("LOCAL_RUN_WAIT_PORT", 1111);
-    client_cache_size = GetIntEnvOrDefault("LOCAL_RUN_CLIENT_CACHE_SIZE", 16384);
-    file_size = GetIntEnvOrDefault("LOCAL_RUN_FILE_SIZE", 4096);
-
-    if (files_per_dir < 1) {
-        files_per_dir = 1;
-    }
-    if (g_mount_per_client < 1) {
-        g_mount_per_client = 1;
-    }
-    if (client_cache_size < 1) {
-        client_cache_size = 1;
-    }
-    if (file_size < 1) {
-        file_size = 4096;
-    }
-}
+std::atomic<uint64_t> g_case_counter(0);
+local_run_test::LocalRunParameters g_params;
 
 std::string BuildRootPath(const char *tag)
 {
-    (void)tag;
-    return fmt::format("{}client_{}_{}/", g_mount_dir, g_client_id, g_wait_port);
+    uint64_t seq = g_case_counter.fetch_add(1, std::memory_order_relaxed);
+    return fmt::format("{}client_{}_{}_{}_{}_{}_{}/",
+                       g_params.mount_dir, g_params.client_id, g_params.wait_port,
+                       tag, getpid(), seq, time(nullptr));
 }
 
-void ResetCounters()
+std::string ThreadDir(const std::string &root, int thread_id)
 {
-    std::memset((void *)op_count, 0, sizeof(op_count));
-    std::memset((void *)latency_count, 0, sizeof(latency_count));
+    return fmt::format("{}thread_{}", root, thread_id);
+}
+
+std::string FilePath(const std::string &root, int thread_id, int file_id)
+{
+    return fmt::format("{}/file_{}", ThreadDir(root, thread_id), file_id);
+}
+
+std::string DirPath(const std::string &root, int thread_id, int dir_id)
+{
+    return fmt::format("{}/dir_{}", ThreadDir(root, thread_id), dir_id);
+}
+
+void ExpectThreadFilesExist(const std::string &root, int thread_id)
+{
+    for (int file_id = 0; file_id < files_per_dir; ++file_id) {
+        struct stat stbuf;
+        SCOPED_TRACE(FilePath(root, thread_id, file_id));
+        EXPECT_EQ(dfs_stat(FilePath(root, thread_id, file_id).c_str(), &stbuf), 0);
+    }
+}
+
+void ExpectFilesExist(const std::string &root)
+{
+    for (int thread_id = 0; thread_id < thread_num; ++thread_id) {
+        ExpectThreadFilesExist(root, thread_id);
+    }
+}
+
+void ExpectDirsExist(const std::string &root)
+{
+    for (int thread_id = 0; thread_id < thread_num; ++thread_id) {
+        for (int dir_id = 0; dir_id < files_per_dir; ++dir_id) {
+            struct stat stbuf;
+            SCOPED_TRACE(DirPath(root, thread_id, dir_id));
+            EXPECT_EQ(dfs_stat(DirPath(root, thread_id, dir_id).c_str(), &stbuf), 0);
+        }
+    }
+}
+
+void ExpectKvRecordExists(const std::string &root)
+{
+    std::string key = fmt::format("{}thread_{}_key_{}", root, 0, 0);
+    uint32_t value_len = 0;
+    uint16_t slice_num = 0;
+    EXPECT_EQ(dfs_kv_get(key.c_str(), &value_len, &slice_num), 0);
+    EXPECT_EQ(value_len, 4096U);
+    EXPECT_EQ(slice_num, 2U);
+}
+
+void ExpectSliceRecordExists(const std::string &root)
+{
+    uint32_t slice_num = 0;
+    EXPECT_EQ(dfs_slice_get(FilePath(root, 0, 0).c_str(), 0, 0, &slice_num), 0);
+    EXPECT_GT(slice_num, 0U);
+}
+
+void InitNamespaceRoot(const std::string &root)
+{
+    int saved_files_per_dir = files_per_dir;
+    files_per_dir = 1 + thread_num;
+    workload_init(root, 0);
+    files_per_dir = saved_files_per_dir;
+}
+
+void UninitNamespaceRoot(const std::string &root)
+{
+    int saved_files_per_dir = files_per_dir;
+    files_per_dir = 1 + thread_num;
+    workload_uninit(root, 0);
+    files_per_dir = saved_files_per_dir;
+}
+
+void RunForEachThread(void (*workload)(std::string, int), const std::string &root)
+{
+    for (int thread_id = 0; thread_id < thread_num; ++thread_id) {
+        workload(root, thread_id);
+    }
 }
 
 bool InitClientOrSkip()
 {
-    setenv("SERVER_IP", GetEnvOrDefault("SERVER_IP", "127.0.0.1").c_str(), 1);
-    setenv("SERVER_PORT", GetEnvOrDefault("SERVER_PORT", "55500").c_str(), 1);
-    LoadLocalRunParameters();
-    ResetCounters();
-    file_num = thread_num * files_per_dir;
+    setenv("SERVER_IP", local_run_test::GetEnvOrDefault("SERVER_IP", "127.0.0.1").c_str(), 1);
+    setenv("SERVER_PORT", local_run_test::GetEnvOrDefault("SERVER_PORT", "55500").c_str(), 1);
+    g_params = local_run_test::LoadLocalRunParameters();
+    local_run_test::ResetCounters();
 
     constexpr int kMaxRetry = 6;
     for (int i = 0; i < kMaxRetry; ++i) {
         try {
-            if (dfs_init(g_client_num) == 0) {
+            if (dfs_init(g_params.client_num) == 0) {
                 return true;
             }
         } catch (...) {
@@ -161,14 +138,9 @@ void CleanupRoot(const std::string &root, bool with_files)
 {
     try {
         if (with_files) {
-            workload_delete(root, 0);
+            RunForEachThread(workload_delete, root);
         }
-        int thread_dir_count = files_per_dir > 1 ? files_per_dir - 1 : 1;
-        for (int i = 0; i < thread_dir_count; ++i) {
-            std::string thread_dir = fmt::format("{}thread_{}", root, i);
-            dfs_rmdir(thread_dir.c_str());
-        }
-        workload_uninit(root, 0);
+        UninitNamespaceRoot(root);
     } catch (...) {
     }
     dfs_shutdown();
@@ -180,7 +152,7 @@ TEST(LocalRunWorkloadUT, InitCreateStatOpenCloseFlow)
 {
     constexpr int kFlowRetry = 2;
     for (int attempt = 0; attempt < kFlowRetry; ++attempt) {
-        if (!EnsureServerOrSkip()) {
+        if (!local_run_test::EnsureConfiguredServer()) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
             continue;
         }
@@ -193,14 +165,12 @@ TEST(LocalRunWorkloadUT, InitCreateStatOpenCloseFlow)
         bool success = false;
         uint64_t start = op_count[0];
         try {
-            int files_per_dir_for_flow = files_per_dir;
-            files_per_dir = 1 + thread_num;
-            workload_init(root, 0);
-            files_per_dir = files_per_dir_for_flow;
+            InitNamespaceRoot(root);
             uint64_t after_init = op_count[0];
 
             workload_create(root, 0);
             uint64_t after_create = op_count[0];
+            ExpectThreadFilesExist(root, 0);
 
             workload_stat(root, 0);
             uint64_t after_stat = op_count[0];
@@ -227,6 +197,108 @@ TEST(LocalRunWorkloadUT, InitCreateStatOpenCloseFlow)
     }
 
     GTEST_SKIP() << "full workload flow failed after retries, likely due unstable service state";
+}
+
+TEST(LocalRunWorkloadUT, FullMetadataKvSliceFlow)
+{
+    constexpr int kFlowRetry = 2;
+    for (int attempt = 0; attempt < kFlowRetry; ++attempt) {
+        if (!local_run_test::EnsureConfiguredServer()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+        if (!InitClientOrSkip()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        std::string root = BuildRootPath("metadata_kv_slice_flow");
+        bool success = false;
+        bool files_deleted = false;
+        bool namespace_removed = false;
+        try {
+            InitNamespaceRoot(root);
+            uint64_t after_init = op_count[0];
+
+            RunForEachThread(workload_create, root);
+            uint64_t after_create = op_count[0];
+            ExpectFilesExist(root);
+
+            RunForEachThread(workload_stat, root);
+            uint64_t after_stat = op_count[0];
+
+            RunForEachThread(workload_open, root);
+            uint64_t after_open = op_count[0];
+
+            RunForEachThread(workload_close, root);
+            uint64_t after_close = op_count[0];
+
+            RunForEachThread(workload_mkdir, root);
+            uint64_t after_mkdir = op_count[0];
+            ExpectDirsExist(root);
+
+            RunForEachThread(workload_rmdir, root);
+            uint64_t after_rmdir = op_count[0];
+
+            RunForEachThread(workload_kv_put, root);
+            uint64_t after_kv_put = op_count[0];
+            ExpectKvRecordExists(root);
+
+            RunForEachThread(workload_kv_get, root);
+            uint64_t after_kv_get = op_count[0];
+
+            RunForEachThread(workload_kv_del, root);
+            uint64_t after_kv_del = op_count[0];
+
+            RunForEachThread(workload_slice_put, root);
+            uint64_t after_slice_put = op_count[0];
+            ExpectSliceRecordExists(root);
+
+            RunForEachThread(workload_slice_get, root);
+            uint64_t after_slice_get = op_count[0];
+
+            RunForEachThread(workload_slice_del, root);
+            uint64_t after_slice_del = op_count[0];
+
+            RunForEachThread(workload_delete, root);
+            files_deleted = true;
+            uint64_t after_delete = op_count[0];
+
+            UninitNamespaceRoot(root);
+            namespace_removed = true;
+            uint64_t after_uninit = op_count[0];
+
+            EXPECT_GT(after_init, 0U);
+            EXPECT_GT(after_create, after_init);
+            EXPECT_GT(after_stat, after_create);
+            EXPECT_GT(after_open, after_stat);
+            EXPECT_GT(after_close, after_open);
+            EXPECT_GT(after_mkdir, after_close);
+            EXPECT_GT(after_rmdir, after_mkdir);
+            EXPECT_GT(after_kv_put, after_rmdir);
+            EXPECT_GT(after_kv_get, after_kv_put);
+            EXPECT_GT(after_kv_del, after_kv_get);
+            EXPECT_GT(after_slice_put, after_kv_del);
+            EXPECT_GT(after_slice_get, after_slice_put);
+            EXPECT_GT(after_slice_del, after_slice_get);
+            EXPECT_GT(after_delete, after_slice_del);
+            EXPECT_GT(after_uninit, after_delete);
+            success = true;
+        } catch (...) {
+        }
+
+        if (namespace_removed) {
+            dfs_shutdown();
+        } else {
+            CleanupRoot(root, !files_deleted);
+        }
+        if (success && !HasFailure()) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+
+    GTEST_SKIP() << "metadata/kv/slice workload flow failed after retries, likely due unstable service state";
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## 变更说明
- 在 `tests/falcon/metadb` 下补充并拆分 metadb 覆盖率用例，按功能分为 DFS/local-run 流程、plain SQL/serialized 入口、standalone helper 和公共工具文件。
- 将原先较大的 metadb 流程型 UT 拆成小粒度用例，例如目录生命周期、属性更新、rename、缺失路径、重复创建、类型不匹配、KV、slice、serialized helper 编解码等，便于定位失败点。
- 按 `falconfs_metadata_DT_test_cases_zh.md` 中目录、文件、rename、属性、KV、slice 相关 DT 场景补充用例注释，并在关键断言附近标明对应 TC 编号。
- 补齐 local-run workload 和 POSIX workload 完整流程用例，覆盖 init、create/stat/open/close、目录、删除、KV、slice 等流程。
- 调整 coverage 执行流程：无服务 UT 先跑，local-run 服务启动后再跑服务依赖 UT；非 `--local-run` 模式下服务依赖用例由测试自身判断服务状态并 skip。
- 将 PR 历史合并为单个提交，当前分支相对 `origin/main` 只有一个提交。

## 覆盖范围
- metadata 正常流程：create、mkdir、opendir、readdir、chmod、chown、utimens、rename、unlink、rmdir。
- 异常/边界流程：重复 create/mkdir、不存在路径、父目录缺失、类型不匹配、非空目录删除、rename 冲突、删除后 stat/open 失败、空路径失败。
- 并发流程：同名目录并发 mkdir、同名文件并发 create、并发 `FETCH_SLICE_ID` 返回非重叠区间。
- KV/slice 流程：KV put/get/delete、重复 key 当前语义、slice id 分配、slice put/get/delete、FILE/KV slice id 分配器入口。
- SQL 流程：`falcon_plain_*`、foreign server cache、shard table renew/reload/update。
- serialized-data 流程：通过 `falcon_meta_call_by_serialized_data()` 构造 flatbuffer 参数直接覆盖序列化入口。

## 文件作用说明
- `build.sh`：将 test 命令切到新的 `run_all_unit_tests`，保持普通测试入口与 coverage 测试入口一致。
- `deploy/coverage/coverage_common.sh`：将原 `run_non_service_unit_tests` 更名为 `run_standalone_unit_tests`，并保留服务依赖 UT 列表；服务依赖 UT 包括 `LocalRunWorkloadUT` 和 `MetadbCoverageUT`。
- `deploy/coverage/coverage_report.sh`：`--local-run` 模式下先跑无服务 UT，再启动 local-run 服务跑服务依赖 UT；非 `--local-run` 模式跑全量 UT，由服务依赖用例自行判断服务状态并 skip。
- `tests/falcon/CMakeLists.txt`：接入 `tests/falcon/metadb` 子目录，让 metadb 覆盖率用例参与测试构建。
- `tests/falcon/metadb/CMakeLists.txt`：定义 `MetadbCoverageUT`，并把 metadb helper 源文件、`workloads.cc`、`falconfs.cc` 编入测试目标。
- `tests/falcon/metadb/test_metadb_coverage_ut.cpp`：只保留 `MetadbCoverageUT` 的 gtest main 入口。
- `tests/falcon/metadb/test_metadb_coverage_common.h`：声明 metadb 覆盖率用例共用的路径构造、客户端初始化、serialized 参数构造、plain SQL 连接等 helper。
- `tests/falcon/metadb/test_metadb_coverage_common.cpp`：实现公共 helper，并定义 workload 依赖的全局变量。
- `tests/falcon/metadb/test_metadb_dfs_flows_ut.cpp`：覆盖 DFS/local-run 服务路径；目前已拆成小粒度用例，分别覆盖目录生命周期、属性更新、rename、缺失路径、重复创建、类型不匹配、非空目录、KV、slice、unlink、深层路径、并发 create、slice id 并发和空路径边界。
- `tests/falcon/metadb/test_metadb_helper_ut.cpp`：覆盖不依赖服务的 serialized helper；目前已拆成参数编码、响应编码、子响应解码、错误码解码、KV 响应、slice 响应、slice-id 响应和 `meta_process_info.c` 路径排序 comparator 等小用例。
- `tests/falcon/metadb/test_metadb_sql_serialized_ut.cpp`：覆盖 plain SQL、admin SQL、serialized-data 直接入口；目前已拆成 plain SQL 目录生命周期、plain SQL 文件/遍历、serialized 目录文件属性、serialized rename、serialized KV、serialized slice 等小用例。
- `tests/private-directory-test/dfs.h`：补充测试中需要直接调用的 DFS 接口声明，例如 rename、chmod、chown、utimens、opendir/readdir、KV、slice 等。
- `tests/private-directory-test/falconfs.cc`：补充 DFS 测试适配层实现，让 workload/metadb 用例可以通过统一的 `dfs_*` 接口触发 Falcon client 或 POSIX 行为。
- `tests/private-directory-test/local_run_workload_test_common.h`：local-run 测试公共 helper，集中处理服务端口探测、环境变量读取、参数归一化和计数器清理。
- `tests/private-directory-test/test_local_run_posix_workload_ut.cpp`：POSIX workload 完整流程测试，覆盖 init、create、stat、open/close、delete、mkdir/rmdir、读写关闭等流程。
- `tests/private-directory-test/test_local_run_workload_ut.cpp`：local-run workload 完整流程测试，覆盖 metadata、目录、KV、slice 等 workload 步骤，并通过 `op_count` 递增和实际查询结果判断流程执行成功。

## 测试结果
- 已执行：`./build.sh coverage --local-run`
- `LocalRunWorkloadUT`：2/2 通过
- `LocalRunPosixWorkloadUT`：2/2 通过
- `MetadbCoverageUT`：29/29 通过，无 skip
- 整体 lcov：行覆盖率 55.3% `(7046/12748)`，函数覆盖率 60.9% `(783/1286)`
- `falcon/metadb` lcov：行覆盖率 85.8% `(2874/3349)`，函数覆盖率 91.7% `(133/145)`

## metadb 逐文件覆盖率
- `meta_handle.c`：行覆盖率 86.8%，函数覆盖率 97.0%
- `meta_serialize_interface.c`：行覆盖率 86.3%，函数覆盖率 100.0%
- `meta_serialize_interface_helper.cpp`：行覆盖率 86.7%，函数覆盖率 87.5%
- `shard_table.c`：行覆盖率 90.1%，函数覆盖率 94.7%
- `directory_table.c`：行覆盖率 85.2%，函数覆盖率 100.0%
- `meta_handle_helper.c`：行覆盖率 80.0%，函数覆盖率 83.3%
- `foreign_server.c`：行覆盖率 77.0%，函数覆盖率 82.4%
- `meta_plain_interface.c`、`meta_process_info.c`、`sliceid_table.c`、`inode_table.c`、`slice_table.c`、`kvmeta_table.c`、`xattr_table.c`：行/函数覆盖率均为 100.0%

## 环境清理检查
- 覆盖率启动前已执行 `falcon_stop.sh`，并检查无 local-run PostgreSQL、FalconFS 服务、UT 进程残留。
- 覆盖率启动前 local-run 相关端口无监听残留，`/home/hx/metadata` 不存在。
- 覆盖率运行结束后脚本停止 local-run 服务；再次检查无 local-run 相关服务进程和端口残留，`/home/hx/metadata` 已清理。
- 覆盖率构建在源码 `falcon/` 下产生的未跟踪 `.gcno` 中间产物已清理；覆盖率报告保留在 `build/coverage`，本轮归档在 `build/coverage_runs/local_run_20260428_113213`。

## ZK 说明
- 当前 PR 的 coverage/local-run 流程不启用 `WITH_ZK_INIT`，因此 ZK 初始化分支不计入本次覆盖率。
- 如果后续要覆盖 ZK 配置链路，建议新增可选 `coverage --with-zk-init` 或 `coverage --zk` 流程，并让 `tests/common/FalconCMIT` 在缺少 `zk_endpoint` 时 `GTEST_SKIP()`。

覆盖率截图：
<img width="2347" height="2267" alt="image" src="https://github.com/user-attachments/assets/2253525f-20f5-4a63-be80-eefa92f2f1cc" />
<img width="2325" height="941" alt="image" src="https://github.com/user-attachments/assets/08fb2486-462e-4d2b-b2d5-0c89a29b8ff3" />
