### PR TITLE
test: add daily private-directory baseline runner

### DIFF
--- a/deploy/meta/falcon_meta_config.sh
+++ b/deploy/meta/falcon_meta_config.sh
@@ -12,7 +12,7 @@ workerPollerPortPrefix=${uniquePortPrefix}3
 cnMonitorPortPrefix=${uniquePortPrefix}8
 workerMonitorPortPrefix=${uniquePortPrefix}9
 
-workspace=$HOME
+workspace=${FALCON_META_WORKSPACE:-$HOME}
 cnPathPrefix=$workspace/metadata/coordinator
 workerPathPrefix=$workspace/metadata/worker
 

--- a/tests/private-directory-test/README.md
+++ b/tests/private-directory-test/README.md
@@ -42,7 +42,7 @@ round_idx,round_name,throughput,avg_latency,ops,time,raw_log
 
 ## Daily Baseline
 
-`run_daily_baseline.sh` is intended for a dedicated local runner account. It updates to `upstream/main`, builds FalconFS, installs FalconFS, restarts the local deployment, and then runs `local-run.sh` for rounds `0 1 2 3`.
+`run_daily_baseline.sh` is intended for a dedicated local runner account. It fetches the configured Git URL/ref, builds FalconFS, installs FalconFS, restarts the local deployment, and then runs `local-run.sh` for rounds `0 1 2 3`.
 
 Create a runner account and checkout. Replace `<runner-user>` with the account used on the target host:
 
@@ -51,12 +51,11 @@ sudo useradd -m -s /bin/bash <runner-user>
 sudo -iu <runner-user>
 git clone https://github.com/falcon-infra/falconfs.git ~/falconfs-baseline-runner
 cd ~/falconfs-baseline-runner
-git remote add upstream https://github.com/falcon-infra/falconfs.git 2>/dev/null || true
-git fetch upstream
-git switch -C baseline/upstream-main upstream/main
+git fetch https://github.com/falcon-infra/falconfs.git main
+git switch -C baseline/main FETCH_HEAD
 ```
 
-If the checkout was cloned from a fork, keep `upstream` pointed at `https://github.com/falcon-infra/falconfs.git` so nightly results always track upstream main.
+The default update source is `https://github.com/falcon-infra/falconfs.git` at ref `main`. Override `FALCONFS_BASELINE_GIT_URL` and `FALCONFS_BASELINE_GIT_REF` if the nightly baseline should track another repository or branch.
 
 Prepare the local mountpoint for the runner account:
 
@@ -87,7 +86,7 @@ local-run.sh
 
 Per-iteration results are written under `iter_1/`, `iter_2/`, and `iter_3/`. The parent `summary.csv` contains the average throughput, average latency, average operation count, and average elapsed time across all iterations.
 
-The wrapper refuses to reset any branch except `baseline/upstream-main` unless `FALCONFS_BASELINE_ALLOW_BRANCH_RESET=1` is set. This protects normal development branches from nightly automation.
+The wrapper refuses to reset any branch except `baseline/main` unless `FALCONFS_BASELINE_ALLOW_BRANCH_RESET=1` is set. This protects normal development branches from nightly automation.
 
 After each run, the wrapper compares the aggregated daily result against the median of recent successful baseline summaries under `FALCONFS_BASELINE_RESULT_ROOT`. The default history window is 7 runs. The default alert rules are a 10% throughput drop or a 10% average latency increase in any round. Latency is reported in `ns/op`.
 
@@ -105,8 +104,9 @@ Useful wrapper overrides:
 
 ```bash
 FALCONFS_BASELINE_RESULT_ROOT=$HOME/falconfs-baseline-results
-FALCONFS_BASELINE_BRANCH=baseline/upstream-main
-FALCONFS_BASELINE_REF=upstream/main
+FALCONFS_BASELINE_BRANCH=baseline/main
+FALCONFS_BASELINE_GIT_URL=https://github.com/falcon-infra/falconfs.git
+FALCONFS_BASELINE_GIT_REF=main
 FALCONFS_BASELINE_UPDATE_GIT=1
 FALCONFS_BASELINE_BUILD=1
 FALCONFS_BASELINE_DEPLOY=1

--- a/tests/private-directory-test/README.md
+++ b/tests/private-directory-test/README.md
@@ -1,19 +1,219 @@
-# Remote test
+# Private Directory Test
 
-Set ALL_SERVERS to actual remote test nodes in distribute.sh, kill_test.sh, remote_run.sh. Enable ssh connection among all nodes, and append the public key of the client node running remote_run.sh to authorized_keys of the nodes in ALL_SERVERS. Modify parameters in remote_run.sh to actual values in used.
+The private directory test drives FalconFS through the LibFS API or POSIX API and prints per-workload IOPS throughput.
 
-``` bash
-bash remote-run.sh
+## Local Test
+
+Run the local test after FalconFS has been built, installed, and deployed locally.
+
+```bash
+bash local-run.sh
 ```
 
-The IOPS throughput will be printed.
+The default local rounds are `0 1 2 3`:
 
-# Local test
+```text
+0 workload_init
+1 workload_create
+2 workload_stat
+3 workload_open
+```
 
-Modify parameters in local_run.sh to actual values in used.
+`local-run.sh` writes raw logs and a CSV summary under `results/<timestamp>/` by default.
 
-``` bash
+The main local overrides are:
+
+```bash
+BIN_DIR=/usr/local/falconfs/private-directory-test/bin \
+TEST_PROGRAM=test_falcon \
+MOUNT_DIR=/ \
+ROUND_INDEX="0 1 2 3" \
+META_SERVER_IP=127.0.0.1 \
+META_SERVER_PORT=55510 \
+RESULT_DIR=/tmp/falconfs-baseline/manual \
 bash local-run.sh
+```
+
+The summary file format is:
+
+```text
+round_idx,round_name,throughput,avg_latency,ops,time,raw_log
+```
+
+## Daily Baseline
+
+`run_daily_baseline.sh` is intended for a dedicated local runner account. It updates to `upstream/main`, builds FalconFS, installs FalconFS, restarts the local deployment, and then runs `local-run.sh` for rounds `0 1 2 3`.
+
+Create a runner account and checkout. Replace `<runner-user>` with the account used on the target host:
+
+```bash
+sudo useradd -m -s /bin/bash <runner-user>
+sudo -iu <runner-user>
+git clone https://github.com/falcon-infra/falconfs.git ~/falconfs-baseline-runner
+cd ~/falconfs-baseline-runner
+git remote add upstream https://github.com/falcon-infra/falconfs.git 2>/dev/null || true
+git fetch upstream
+git switch -C baseline/upstream-main upstream/main
+```
+
+If the checkout was cloned from a fork, keep `upstream` pointed at `https://github.com/falcon-infra/falconfs.git` so nightly results always track upstream main.
+
+Prepare the local mountpoint for the runner account:
+
+```bash
+sudo mkdir -p /tmp/falcon_mnt
+sudo chown <runner-user>:<runner-group> /tmp/falcon_mnt
+```
+
+Run one daily baseline manually as the runner account:
+
+```bash
+sudo -iu <runner-user>
+~/falconfs-baseline-runner/tests/private-directory-test/run_daily_baseline.sh
+```
+
+Results are written to `~/falconfs-baseline-results/<timestamp>/` by default. Each run includes `run_info.env`, `git_status.txt`, per-round raw logs, `summary.csv`, `baseline_report.txt`, and `email_preview.txt`.
+
+The wrapper uses this deploy flow by default:
+
+```bash
+./build.sh clean falcon
+./build.sh build falcon
+sudo -n ./build.sh install falcon
+./deploy/falcon_stop.sh
+./deploy/falcon_start.sh
+```
+
+The wrapper refuses to reset any branch except `baseline/upstream-main` unless `FALCONFS_BASELINE_ALLOW_BRANCH_RESET=1` is set. This protects normal development branches from nightly automation.
+
+After each run, the wrapper compares current throughput against the median of the most recent successful baseline summaries under `FALCONFS_BASELINE_RESULT_ROOT`. The default window is 7 runs, and the default alert threshold is a 10% throughput drop in any round. If a suspected degradation is detected, the wrapper reruns only the benchmark once for confirmation and then regenerates the report.
+
+Email sending is disabled by default. `email_preview.txt` is always generated so the report can be inspected without SMTP credentials.
+
+Useful wrapper overrides:
+
+```bash
+FALCONFS_BASELINE_RESULT_ROOT=$HOME/falconfs-baseline-results
+FALCONFS_BASELINE_BRANCH=baseline/upstream-main
+FALCONFS_BASELINE_REF=upstream/main
+FALCONFS_BASELINE_UPDATE_GIT=1
+FALCONFS_BASELINE_BUILD=1
+FALCONFS_BASELINE_DEPLOY=1
+FALCONFS_BASELINE_ROUNDS="0 1 2 3"
+FALCONFS_BASELINE_META_SERVER_IP=127.0.0.1
+FALCONFS_BASELINE_META_SERVER_PORT=55510
+FALCONFS_BASELINE_SUDO_CMD="sudo -n"
+FALCONFS_BASELINE_HISTORY_WINDOW=7
+FALCONFS_BASELINE_MIN_HISTORY=3
+FALCONFS_BASELINE_ALERT_THRESHOLD_PCT=10
+FALCONFS_BASELINE_CONFIRM_ON_DEGRADATION=1
+FALCONFS_BASELINE_MAIL_ENABLED=0
+```
+
+To enable SMTP email, provide the SMTP settings through environment variables or a systemd environment file. Do not commit credentials to the repository.
+
+```bash
+FALCONFS_BASELINE_MAIL_ENABLED=1
+FALCONFS_BASELINE_MAIL_FROM=<sender@example.com>
+FALCONFS_BASELINE_MAIL_TO=<receiver@example.com>
+FALCONFS_BASELINE_SMTP_HOST=<smtp-host>
+FALCONFS_BASELINE_SMTP_PORT=465
+FALCONFS_BASELINE_SMTP_USER=<smtp-user>
+FALCONFS_BASELINE_SMTP_PASSWORD=<smtp-password-or-token>
+FALCONFS_BASELINE_SMTP_SSL=1
+FALCONFS_BASELINE_SMTP_TLS_VERIFY=0
+```
+
+For STARTTLS on port 587, use:
+
+```bash
+FALCONFS_BASELINE_SMTP_SSL=0
+FALCONFS_BASELINE_SMTP_STARTTLS=1
+```
+
+SMTP certificate verification is disabled by default to support internal mail gateways with private CA chains. To enable verification, install the company CA on the host or point the report script at the CA bundle:
+
+```bash
+FALCONFS_BASELINE_SMTP_TLS_VERIFY=1
+FALCONFS_BASELINE_SMTP_CA_FILE=/path/to/company-ca.pem
+```
+
+For systemd, keep secrets outside the unit file, for example:
+
+```ini
+EnvironmentFile=/etc/falconfs/baseline-mail.env
+```
+
+`sudo -n` requires passwordless sudo for the install and deployment steps used by FalconFS. Configure sudoers for the runner account instead of running the full timer as root.
+
+For example, start with a dedicated sudoers file and narrow it further for the target host:
+
+```bash
+sudo visudo -f /etc/sudoers.d/<runner-user>
+```
+
+```text
+<runner-user> ALL=(ALL) NOPASSWD: /home/<runner-user>/falconfs-baseline-runner/build.sh
+<runner-user> ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/cp, /usr/bin/rm, /usr/bin/umount, /usr/bin/kill
+```
+
+The deploy scripts call `sudo` internally for PostgreSQL extension installation, extension cleanup, and FUSE unmount cleanup. Adjust command paths if they differ on the host.
+
+## systemd Timer
+
+Use a system timer with `User=<runner-user>` to run the baseline every day at midnight.
+
+`/etc/systemd/system/falconfs-daily-baseline.service`:
+
+```ini
+[Unit]
+Description=FalconFS daily private-directory baseline
+
+[Service]
+Type=oneshot
+User=<runner-user>
+Group=<runner-group>
+Environment=HOME=/home/<runner-user>
+WorkingDirectory=/home/<runner-user>/falconfs-baseline-runner
+ExecStart=/home/<runner-user>/falconfs-baseline-runner/tests/private-directory-test/run_daily_baseline.sh
+TimeoutStartSec=4h
+```
+
+`/etc/systemd/system/falconfs-daily-baseline.timer`:
+
+```ini
+[Unit]
+Description=Run FalconFS daily private-directory baseline
+
+[Timer]
+OnCalendar=*-*-* 00:00:00
+Persistent=true
+Unit=falconfs-daily-baseline.service
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable the timer:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now falconfs-daily-baseline.timer
+systemctl list-timers falconfs-daily-baseline.timer
+```
+
+View logs:
+
+```bash
+sudo journalctl -u falconfs-daily-baseline.service
+```
+
+## Remote Test
+
+Set `ALL_SERVERS` to actual remote test nodes in `distribute.sh`, `kill_test.sh`, and `remote-run.sh`. Enable SSH among all nodes, and append the public key of the client node running `remote-run.sh` to `authorized_keys` on the nodes in `ALL_SERVERS`.
+
+```bash
+bash remote-run.sh
 ```
 
 The IOPS throughput will be printed.

--- a/tests/private-directory-test/README.md
+++ b/tests/private-directory-test/README.md
@@ -72,21 +72,32 @@ sudo -iu <runner-user>
 ~/falconfs-baseline-runner/tests/private-directory-test/run_daily_baseline.sh
 ```
 
-Results are written to `~/falconfs-baseline-results/<timestamp>/` by default. Each run includes `run_info.env`, `git_status.txt`, per-round raw logs, `summary.csv`, `baseline_report.txt`, and `email_preview.txt`.
+Results are written to `~/falconfs-baseline-results/<timestamp>/` by default. Each run includes `run_info.env`, `git_status.txt`, `host_info.txt`, per-iteration raw logs, aggregated `summary.csv`, `baseline_report.txt`, and `email_preview.txt`.
 
-The wrapper uses this deploy flow by default:
+The wrapper runs three complete iterations by default. Each iteration uses this flow:
 
 ```bash
+./deploy/falcon_stop.sh
 ./build.sh clean falcon
 ./build.sh build falcon
 sudo -n ./build.sh install falcon
-./deploy/falcon_stop.sh
 ./deploy/falcon_start.sh
+local-run.sh
 ```
+
+Per-iteration results are written under `iter_1/`, `iter_2/`, and `iter_3/`. The parent `summary.csv` contains the average throughput, average latency, average operation count, and average elapsed time across all iterations.
 
 The wrapper refuses to reset any branch except `baseline/upstream-main` unless `FALCONFS_BASELINE_ALLOW_BRANCH_RESET=1` is set. This protects normal development branches from nightly automation.
 
-After each run, the wrapper compares current throughput against the median of the most recent successful baseline summaries under `FALCONFS_BASELINE_RESULT_ROOT`. The default window is 7 runs, and the default alert threshold is a 10% throughput drop in any round. If a suspected degradation is detected, the wrapper reruns only the benchmark once for confirmation and then regenerates the report.
+After each run, the wrapper compares the aggregated daily result against the median of recent successful baseline summaries under `FALCONFS_BASELINE_RESULT_ROOT`. The default history window is 7 runs. The default alert rules are a 10% throughput drop or a 10% average latency increase in any round. Latency is reported in `ns/op`.
+
+The report includes host metadata from `host_info.txt`, including hostname, primary IP, user, repo path, result path, kernel, OS, CPU model, CPU count, memory, iteration count, rounds, and benchmark parameters.
+
+Smoke runs should use a separate result root so they do not pollute daily history:
+
+```bash
+FALCONFS_BASELINE_RESULT_ROOT=$HOME/falconfs-baseline-smoke-results
+```
 
 Email sending is disabled by default. `email_preview.txt` is always generated so the report can be inspected without SMTP credentials.
 
@@ -103,10 +114,12 @@ FALCONFS_BASELINE_ROUNDS="0 1 2 3"
 FALCONFS_BASELINE_META_SERVER_IP=127.0.0.1
 FALCONFS_BASELINE_META_SERVER_PORT=55510
 FALCONFS_BASELINE_SUDO_CMD="sudo -n"
+FALCONFS_BASELINE_ITERATIONS=3
 FALCONFS_BASELINE_HISTORY_WINDOW=7
 FALCONFS_BASELINE_MIN_HISTORY=3
 FALCONFS_BASELINE_ALERT_THRESHOLD_PCT=10
-FALCONFS_BASELINE_CONFIRM_ON_DEGRADATION=1
+FALCONFS_BASELINE_LATENCY_ALERT_THRESHOLD_PCT=10
+FALCONFS_BASELINE_LATENCY_ALERT_ENABLED=1
 FALCONFS_BASELINE_MAIL_ENABLED=0
 ```
 

--- a/tests/private-directory-test/README.md
+++ b/tests/private-directory-test/README.md
@@ -187,10 +187,14 @@ Type=oneshot
 User=<runner-user>
 Group=<runner-group>
 Environment=HOME=/home/<runner-user>
+Environment=FALCON_META_WORKSPACE=/path/to/fast/local/disk
 WorkingDirectory=/home/<runner-user>/falconfs-baseline-runner
+ExecStartPre=+/usr/bin/install -d -o <runner-user> -g <runner-group> -m 0755 /path/to/fast/local/disk
 ExecStart=/home/<runner-user>/falconfs-baseline-runner/tests/private-directory-test/run_daily_baseline.sh
 TimeoutStartSec=4h
 ```
+
+`FALCON_META_WORKSPACE` is optional. Set it when metadata should live outside `$HOME`, for example on a local NVMe disk. The deployment scripts store metadata under `$FALCON_META_WORKSPACE/metadata`.
 
 `/etc/systemd/system/falconfs-daily-baseline.timer`:
 

--- a/tests/private-directory-test/baseline_report.py
+++ b/tests/private-directory-test/baseline_report.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from pathlib import Path
+from statistics import median
+
+
+ALERT_EXIT_CODE = 10
+
+
+def read_summary(result_dir):
+    summary_path = Path(result_dir) / "summary.csv"
+    if not summary_path.is_file():
+        return None
+
+    rows = {}
+    with summary_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row.get("round_name", "").strip()
+            if not name:
+                continue
+            try:
+                throughput = float(row.get("throughput", ""))
+            except ValueError:
+                continue
+            rows[name] = {
+                "round_idx": row.get("round_idx", ""),
+                "throughput": throughput,
+                "avg_latency": row.get("avg_latency", ""),
+                "ops": row.get("ops", ""),
+                "time": row.get("time", ""),
+                "raw_log": row.get("raw_log", ""),
+            }
+
+    return rows if rows else None
+
+
+def read_run_info(result_dir):
+    info = {}
+    path = Path(result_dir) / "run_info.env"
+    if not path.is_file():
+        return info
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            info[key] = value
+    return info
+
+
+def candidate_history_dirs(result_root, exclude_dirs):
+    root = Path(result_root)
+    if not root.is_dir():
+        return []
+
+    excludes = {Path(p).resolve() for p in exclude_dirs if p}
+    candidates = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        resolved = child.resolve()
+        if resolved in excludes:
+            continue
+        if child.name.endswith("_confirm"):
+            continue
+        summary_path = child / "summary.csv"
+        if not summary_path.is_file():
+            continue
+        candidates.append(child)
+
+    candidates.sort(key=lambda p: (p / "summary.csv").stat().st_mtime, reverse=True)
+    return candidates
+
+
+def load_history(result_root, exclude_dirs, window):
+    history = []
+    for result_dir in candidate_history_dirs(result_root, exclude_dirs):
+        summary = read_summary(result_dir)
+        if summary:
+            history.append({"dir": str(result_dir), "summary": summary})
+        if len(history) >= window:
+            break
+    return history
+
+
+def build_baseline(history, round_names, min_history):
+    baseline = {}
+    for name in round_names:
+        values = [entry["summary"][name]["throughput"] for entry in history if name in entry["summary"]]
+        if len(values) >= min_history:
+            baseline[name] = {
+                "median": median(values),
+                "samples": len(values),
+            }
+    return baseline
+
+
+def compare(summary, baseline, threshold):
+    results = []
+    for name, row in summary.items():
+        current = row["throughput"]
+        base = baseline.get(name)
+        if not base:
+            results.append({
+                "round_name": name,
+                "current": current,
+                "baseline": None,
+                "samples": 0,
+                "delta_pct": None,
+                "degraded": False,
+            })
+            continue
+
+        base_value = base["median"]
+        delta_pct = ((current - base_value) / base_value) * 100 if base_value else 0.0
+        results.append({
+            "round_name": name,
+            "current": current,
+            "baseline": base_value,
+            "samples": base["samples"],
+            "delta_pct": delta_pct,
+            "degraded": current < base_value * (1 - threshold),
+        })
+    return results
+
+
+def format_float(value):
+    if value is None:
+        return "n/a"
+    return f"{value:.2f}"
+
+
+def format_pct(value):
+    if value is None:
+        return "n/a"
+    return f"{value:.2f}%"
+
+
+def status_from_results(primary_results, confirm_results, history_count):
+    primary_degraded = any(row["degraded"] for row in primary_results)
+    confirm_degraded = any(row["degraded"] for row in confirm_results) if confirm_results is not None else False
+
+    if history_count == 0:
+        return "NO_HISTORY"
+    if confirm_results is not None and primary_degraded and not confirm_degraded:
+        return "TRANSIENT"
+    if confirm_results is not None and confirm_degraded:
+        return "ALERT"
+    if primary_degraded:
+        return "SUSPECT"
+    return "OK"
+
+
+def build_report(args, current_summary, history, baseline, primary_results, confirm_summary, confirm_results):
+    info = read_run_info(args.current_dir)
+    history_dirs = [entry["dir"] for entry in history]
+    status = status_from_results(primary_results, confirm_results, len(history))
+
+    lines = []
+    lines.append(f"FalconFS daily baseline status: {status}")
+    lines.append("")
+    lines.append(f"Current result: {args.current_dir}")
+    lines.append(f"Commit: {info.get('commit_sha', 'n/a')}")
+    lines.append(f"Subject: {info.get('commit_subject', 'n/a')}")
+    lines.append(f"Git dirty: {info.get('git_dirty', 'n/a')}")
+    lines.append(f"History samples: {len(history_dirs)} (window={args.history_window}, min={args.min_history})")
+    lines.append(f"Alert threshold: -{args.threshold_pct:.1f}%")
+    if args.confirm_dir:
+        lines.append(f"Confirm result: {args.confirm_dir}")
+    lines.append("")
+
+    lines.append("Round throughput comparison:")
+    lines.append("round,current,median,delta,samples,status")
+    for row in primary_results:
+        row_status = "DEGRADED" if row["degraded"] else "OK"
+        lines.append(
+            f"{row['round_name']},{format_float(row['current'])},{format_float(row['baseline'])},"
+            f"{format_pct(row['delta_pct'])},{row['samples']},{row_status}"
+        )
+
+    if confirm_results is not None:
+        lines.append("")
+        lines.append("Confirm run comparison:")
+        lines.append("round,current,median,delta,samples,status")
+        for row in confirm_results:
+            row_status = "DEGRADED" if row["degraded"] else "OK"
+            lines.append(
+                f"{row['round_name']},{format_float(row['current'])},{format_float(row['baseline'])},"
+                f"{format_pct(row['delta_pct'])},{row['samples']},{row_status}"
+            )
+
+    lines.append("")
+    lines.append("History result dirs:")
+    if history_dirs:
+        lines.extend(history_dirs)
+    else:
+        lines.append("n/a")
+
+    return status, "\n".join(lines) + "\n"
+
+
+def mail_subject(status, current_dir):
+    prefix = os.environ.get("FALCONFS_BASELINE_MAIL_SUBJECT_PREFIX", "[FalconFS baseline]")
+    run_name = Path(current_dir).name
+    if status == "ALERT":
+        return f"{prefix}[ALERT] throughput degraded >10% {run_name}"
+    if status == "SUSPECT":
+        return f"{prefix}[SUSPECT] throughput degraded, confirmation pending {run_name}"
+    if status == "TRANSIENT":
+        return f"{prefix}[OK] transient throughput dip recovered {run_name}"
+    return f"{prefix}[{status}] {run_name}"
+
+
+def write_outputs(result_dir, status, report):
+    result_path = Path(result_dir)
+    (result_path / "baseline_report.txt").write_text(report, encoding="utf-8")
+    subject = mail_subject(status, result_dir)
+    preview = f"Subject: {subject}\n\n{report}"
+    (result_path / "email_preview.txt").write_text(preview, encoding="utf-8")
+    return subject
+
+
+def send_mail(subject, report):
+    if os.environ.get("FALCONFS_BASELINE_MAIL_ENABLED", "0") != "1":
+        return False
+
+    host = os.environ["FALCONFS_BASELINE_SMTP_HOST"]
+    port = int(os.environ.get("FALCONFS_BASELINE_SMTP_PORT", "465"))
+    user = os.environ["FALCONFS_BASELINE_SMTP_USER"]
+    password = os.environ["FALCONFS_BASELINE_SMTP_PASSWORD"]
+    sender = os.environ["FALCONFS_BASELINE_MAIL_FROM"]
+    recipients = [item.strip() for item in os.environ["FALCONFS_BASELINE_MAIL_TO"].split(",") if item.strip()]
+    use_ssl = os.environ.get("FALCONFS_BASELINE_SMTP_SSL", "1") == "1"
+    use_starttls = os.environ.get("FALCONFS_BASELINE_SMTP_STARTTLS", "0") == "1"
+    tls_verify = os.environ.get("FALCONFS_BASELINE_SMTP_TLS_VERIFY", "0") == "1"
+    ca_file = os.environ.get("FALCONFS_BASELINE_SMTP_CA_FILE", "")
+
+    if tls_verify:
+        context = ssl.create_default_context(cafile=ca_file or None)
+    else:
+        context = ssl._create_unverified_context()
+
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["To"] = ", ".join(recipients)
+    msg["Subject"] = subject
+    msg.set_content(report)
+
+    if use_ssl:
+        with smtplib.SMTP_SSL(host, port, context=context, timeout=30) as smtp:
+            smtp.login(user, password)
+            smtp.send_message(msg)
+    else:
+        with smtplib.SMTP(host, port, timeout=30) as smtp:
+            if use_starttls:
+                smtp.starttls(context=context)
+            smtp.login(user, password)
+            smtp.send_message(msg)
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate FalconFS baseline report and optional email.")
+    parser.add_argument("--result-root", required=True)
+    parser.add_argument("--current-dir", required=True)
+    parser.add_argument("--confirm-dir", default="")
+    parser.add_argument("--history-window", type=int, default=int(os.environ.get("FALCONFS_BASELINE_HISTORY_WINDOW", "7")))
+    parser.add_argument("--min-history", type=int, default=int(os.environ.get("FALCONFS_BASELINE_MIN_HISTORY", "3")))
+    parser.add_argument("--threshold-pct", type=float, default=float(os.environ.get("FALCONFS_BASELINE_ALERT_THRESHOLD_PCT", "10")))
+    args = parser.parse_args()
+
+    args.current_dir = str(Path(args.current_dir).resolve())
+    args.confirm_dir = str(Path(args.confirm_dir).resolve()) if args.confirm_dir else ""
+    threshold = args.threshold_pct / 100.0
+
+    current_summary = read_summary(args.current_dir)
+    if not current_summary:
+        raise SystemExit(f"missing or empty summary.csv in {args.current_dir}")
+
+    confirm_summary = read_summary(args.confirm_dir) if args.confirm_dir else None
+    history = load_history(args.result_root, [args.current_dir, args.confirm_dir], args.history_window)
+    baseline = build_baseline(history, current_summary.keys(), args.min_history)
+    primary_results = compare(current_summary, baseline, threshold)
+    confirm_results = compare(confirm_summary, baseline, threshold) if confirm_summary else None
+    status, report = build_report(args, current_summary, history, baseline, primary_results, confirm_summary, confirm_results)
+    subject = write_outputs(args.current_dir, status, report)
+
+    sent = send_mail(subject, report)
+    print(f"baseline report status: {status}")
+    print(f"baseline report: {Path(args.current_dir) / 'baseline_report.txt'}")
+    print(f"email preview: {Path(args.current_dir) / 'email_preview.txt'}")
+    if sent:
+        print("email sent")
+    else:
+        print("email not sent (set FALCONFS_BASELINE_MAIL_ENABLED=1 and SMTP env vars to enable)")
+
+    if status == "SUSPECT":
+        raise SystemExit(ALERT_EXIT_CODE)
+    if status == "ALERT":
+        raise SystemExit(ALERT_EXIT_CODE)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/private-directory-test/baseline_report.py
+++ b/tests/private-directory-test/baseline_report.py
@@ -12,6 +12,13 @@ from statistics import median
 ALERT_EXIT_CODE = 10
 
 
+def parse_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def read_summary(result_dir):
     summary_path = Path(result_dir) / "summary.csv"
     if not summary_path.is_file():
@@ -22,27 +29,26 @@ def read_summary(result_dir):
         reader = csv.DictReader(f)
         for row in reader:
             name = row.get("round_name", "").strip()
-            if not name:
+            throughput = parse_float(row.get("throughput", ""))
+            if not name or throughput is None:
                 continue
-            try:
-                throughput = float(row.get("throughput", ""))
-            except ValueError:
-                continue
+            latency = parse_float(row.get("avg_latency", ""))
             rows[name] = {
                 "round_idx": row.get("round_idx", ""),
                 "throughput": throughput,
-                "avg_latency": row.get("avg_latency", ""),
-                "ops": row.get("ops", ""),
-                "time": row.get("time", ""),
+                "avg_latency": latency if latency is not None and latency > 0 else None,
+                "ops": parse_float(row.get("ops", "")),
+                "time": parse_float(row.get("time", "")),
+                "iterations": row.get("iterations", ""),
                 "raw_log": row.get("raw_log", ""),
             }
 
     return rows if rows else None
 
 
-def read_run_info(result_dir):
+def read_key_value_file(path):
     info = {}
-    path = Path(result_dir) / "run_info.env"
+    path = Path(path)
     if not path.is_file():
         return info
     with path.open(encoding="utf-8") as f:
@@ -53,6 +59,14 @@ def read_run_info(result_dir):
             key, value = line.split("=", 1)
             info[key] = value
     return info
+
+
+def read_run_info(result_dir):
+    return read_key_value_file(Path(result_dir) / "run_info.env")
+
+
+def read_host_info(result_dir):
+    return read_key_value_file(Path(result_dir) / "host_info.txt")
 
 
 def candidate_history_dirs(result_root, exclude_dirs):
@@ -68,7 +82,7 @@ def candidate_history_dirs(result_root, exclude_dirs):
         resolved = child.resolve()
         if resolved in excludes:
             continue
-        if child.name.endswith("_confirm"):
+        if child.name.endswith("_confirm") or child.name.startswith("iter_"):
             continue
         summary_path = child / "summary.csv"
         if not summary_path.is_file():
@@ -93,42 +107,90 @@ def load_history(result_root, exclude_dirs, window):
 def build_baseline(history, round_names, min_history):
     baseline = {}
     for name in round_names:
-        values = [entry["summary"][name]["throughput"] for entry in history if name in entry["summary"]]
-        if len(values) >= min_history:
-            baseline[name] = {
-                "median": median(values),
-                "samples": len(values),
+        throughput_values = [
+            entry["summary"][name]["throughput"]
+            for entry in history
+            if name in entry["summary"] and entry["summary"][name]["throughput"] is not None
+        ]
+        latency_values = [
+            entry["summary"][name]["avg_latency"]
+            for entry in history
+            if name in entry["summary"] and entry["summary"][name]["avg_latency"] is not None
+        ]
+        baseline[name] = {}
+        if len(throughput_values) >= min_history:
+            baseline[name]["throughput"] = {
+                "median": median(throughput_values),
+                "samples": len(throughput_values),
+            }
+        if len(latency_values) >= min_history:
+            baseline[name]["latency"] = {
+                "median": median(latency_values),
+                "samples": len(latency_values),
             }
     return baseline
 
 
-def compare(summary, baseline, threshold):
+def compare_throughput(summary, baseline, threshold):
     results = []
     for name, row in summary.items():
         current = row["throughput"]
-        base = baseline.get(name)
-        if not base:
-            results.append({
-                "round_name": name,
-                "current": current,
-                "baseline": None,
-                "samples": 0,
-                "delta_pct": None,
-                "degraded": False,
-            })
-            continue
-
-        base_value = base["median"]
-        delta_pct = ((current - base_value) / base_value) * 100 if base_value else 0.0
-        results.append({
-            "round_name": name,
-            "current": current,
-            "baseline": base_value,
-            "samples": base["samples"],
-            "delta_pct": delta_pct,
-            "degraded": current < base_value * (1 - threshold),
-        })
+        base = baseline.get(name, {}).get("throughput")
+        result = compare_value(name, current, base, lower_is_bad=True, threshold=threshold)
+        results.append(result)
     return results
+
+
+def compare_latency(summary, baseline, threshold, enabled):
+    results = []
+    for name, row in summary.items():
+        current = row["avg_latency"]
+        base = baseline.get(name, {}).get("latency")
+        result = compare_value(name, current, base, lower_is_bad=False, threshold=threshold)
+        if not enabled:
+            result["degraded"] = False
+            result["status"] = "DISABLED"
+        results.append(result)
+    return results
+
+
+def compare_value(round_name, current, baseline, lower_is_bad, threshold):
+    if current is None:
+        return {
+            "round_name": round_name,
+            "current": None,
+            "baseline": None,
+            "samples": 0,
+            "delta_pct": None,
+            "degraded": False,
+            "status": "NO_DATA",
+        }
+    if not baseline:
+        return {
+            "round_name": round_name,
+            "current": current,
+            "baseline": None,
+            "samples": 0,
+            "delta_pct": None,
+            "degraded": False,
+            "status": "NO_BASELINE",
+        }
+
+    base_value = baseline["median"]
+    delta_pct = ((current - base_value) / base_value) * 100 if base_value else 0.0
+    if lower_is_bad:
+        degraded = current < base_value * (1 - threshold)
+    else:
+        degraded = current > base_value * (1 + threshold)
+    return {
+        "round_name": round_name,
+        "current": current,
+        "baseline": base_value,
+        "samples": baseline["samples"],
+        "delta_pct": delta_pct,
+        "degraded": degraded,
+        "status": "DEGRADED" if degraded else "OK",
+    }
 
 
 def format_float(value):
@@ -143,58 +205,68 @@ def format_pct(value):
     return f"{value:.2f}%"
 
 
-def status_from_results(primary_results, confirm_results, history_count):
-    primary_degraded = any(row["degraded"] for row in primary_results)
-    confirm_degraded = any(row["degraded"] for row in confirm_results) if confirm_results is not None else False
-
+def status_from_results(throughput_results, latency_results, history_count):
     if history_count == 0:
         return "NO_HISTORY"
-    if confirm_results is not None and primary_degraded and not confirm_degraded:
-        return "TRANSIENT"
-    if confirm_results is not None and confirm_degraded:
+    if any(row["degraded"] for row in throughput_results + latency_results):
         return "ALERT"
-    if primary_degraded:
-        return "SUSPECT"
     return "OK"
 
 
-def build_report(args, current_summary, history, baseline, primary_results, confirm_summary, confirm_results):
-    info = read_run_info(args.current_dir)
+def host_summary_lines(host_info, run_info):
+    fields = [
+        ("Host", host_info.get("hostname", "n/a")),
+        ("Primary IP", host_info.get("primary_ip", "n/a")),
+        ("User", host_info.get("user", "n/a")),
+        ("Repo", host_info.get("repo_dir", run_info.get("repo_dir", "n/a"))),
+        ("Result", host_info.get("result_dir", run_info.get("result_dir", "n/a"))),
+        ("Commit", run_info.get("commit_sha", "n/a")),
+        ("Subject", run_info.get("commit_subject", "n/a")),
+        ("Git dirty", run_info.get("git_dirty", "n/a")),
+        ("Kernel", host_info.get("kernel", "n/a")),
+        ("OS", host_info.get("os_release", "n/a")),
+        ("CPU", host_info.get("cpu_model", "n/a")),
+        ("CPU count", host_info.get("cpu_count", "n/a")),
+        ("Memory", host_info.get("mem_total", "n/a")),
+        ("Iterations", host_info.get("iterations", run_info.get("iterations", "n/a"))),
+        ("Rounds", host_info.get("rounds", run_info.get("rounds", "n/a"))),
+        ("Files/thread", host_info.get("file_per_thread", run_info.get("file_per_thread", "n/a"))),
+        ("Threads/client", host_info.get("thread_num_per_client", run_info.get("thread_num_per_client", "n/a"))),
+        ("Client num", host_info.get("client_num", run_info.get("client_num", "n/a"))),
+        ("File size", host_info.get("file_size", run_info.get("file_size", "n/a"))),
+    ]
+    return [f"{key}: {value}" for key, value in fields]
+
+
+def append_table(lines, title, results):
+    lines.append(title)
+    lines.append("round,current,median,delta,samples,status")
+    for row in results:
+        lines.append(
+            f"{row['round_name']},{format_float(row['current'])},{format_float(row['baseline'])},"
+            f"{format_pct(row['delta_pct'])},{row['samples']},{row['status']}"
+        )
+
+
+def build_report(args, history, throughput_results, latency_results):
+    run_info = read_run_info(args.current_dir)
+    host_info = read_host_info(args.current_dir)
     history_dirs = [entry["dir"] for entry in history]
-    status = status_from_results(primary_results, confirm_results, len(history))
+    status = status_from_results(throughput_results, latency_results, len(history))
 
     lines = []
     lines.append(f"FalconFS daily baseline status: {status}")
     lines.append("")
-    lines.append(f"Current result: {args.current_dir}")
-    lines.append(f"Commit: {info.get('commit_sha', 'n/a')}")
-    lines.append(f"Subject: {info.get('commit_subject', 'n/a')}")
-    lines.append(f"Git dirty: {info.get('git_dirty', 'n/a')}")
+    lines.extend(host_summary_lines(host_info, run_info))
+    lines.append("")
     lines.append(f"History samples: {len(history_dirs)} (window={args.history_window}, min={args.min_history})")
-    lines.append(f"Alert threshold: -{args.threshold_pct:.1f}%")
-    if args.confirm_dir:
-        lines.append(f"Confirm result: {args.confirm_dir}")
+    lines.append(f"Throughput alert threshold: -{args.threshold_pct:.1f}%")
+    lines.append(f"Latency alert threshold: +{args.latency_threshold_pct:.1f}%")
     lines.append("")
 
-    lines.append("Round throughput comparison:")
-    lines.append("round,current,median,delta,samples,status")
-    for row in primary_results:
-        row_status = "DEGRADED" if row["degraded"] else "OK"
-        lines.append(
-            f"{row['round_name']},{format_float(row['current'])},{format_float(row['baseline'])},"
-            f"{format_pct(row['delta_pct'])},{row['samples']},{row_status}"
-        )
-
-    if confirm_results is not None:
-        lines.append("")
-        lines.append("Confirm run comparison:")
-        lines.append("round,current,median,delta,samples,status")
-        for row in confirm_results:
-            row_status = "DEGRADED" if row["degraded"] else "OK"
-            lines.append(
-                f"{row['round_name']},{format_float(row['current'])},{format_float(row['baseline'])},"
-                f"{format_pct(row['delta_pct'])},{row['samples']},{row_status}"
-            )
+    append_table(lines, "Round throughput comparison:", throughput_results)
+    lines.append("")
+    append_table(lines, "Round latency comparison (ns/op):", latency_results)
 
     lines.append("")
     lines.append("History result dirs:")
@@ -206,22 +278,26 @@ def build_report(args, current_summary, history, baseline, primary_results, conf
     return status, "\n".join(lines) + "\n"
 
 
-def mail_subject(status, current_dir):
+def mail_subject(status, current_dir, throughput_results, latency_results):
     prefix = os.environ.get("FALCONFS_BASELINE_MAIL_SUBJECT_PREFIX", "[FalconFS baseline]")
     run_name = Path(current_dir).name
+    throughput_bad = any(row["degraded"] for row in throughput_results)
+    latency_bad = any(row["degraded"] for row in latency_results)
     if status == "ALERT":
-        return f"{prefix}[ALERT] throughput degraded >10% {run_name}"
-    if status == "SUSPECT":
-        return f"{prefix}[SUSPECT] throughput degraded, confirmation pending {run_name}"
-    if status == "TRANSIENT":
-        return f"{prefix}[OK] transient throughput dip recovered {run_name}"
+        if throughput_bad and latency_bad:
+            reason = "throughput/latency regression"
+        elif throughput_bad:
+            reason = "throughput degraded >10%"
+        else:
+            reason = "latency regressed >10%"
+        return f"{prefix}[ALERT] {reason} {run_name}"
     return f"{prefix}[{status}] {run_name}"
 
 
-def write_outputs(result_dir, status, report):
+def write_outputs(result_dir, status, report, throughput_results, latency_results):
     result_path = Path(result_dir)
     (result_path / "baseline_report.txt").write_text(report, encoding="utf-8")
-    subject = mail_subject(status, result_dir)
+    subject = mail_subject(status, result_dir, throughput_results, latency_results)
     preview = f"Subject: {subject}\n\n{report}"
     (result_path / "email_preview.txt").write_text(preview, encoding="utf-8")
     return subject
@@ -270,27 +346,28 @@ def main():
     parser = argparse.ArgumentParser(description="Generate FalconFS baseline report and optional email.")
     parser.add_argument("--result-root", required=True)
     parser.add_argument("--current-dir", required=True)
-    parser.add_argument("--confirm-dir", default="")
     parser.add_argument("--history-window", type=int, default=int(os.environ.get("FALCONFS_BASELINE_HISTORY_WINDOW", "7")))
     parser.add_argument("--min-history", type=int, default=int(os.environ.get("FALCONFS_BASELINE_MIN_HISTORY", "3")))
     parser.add_argument("--threshold-pct", type=float, default=float(os.environ.get("FALCONFS_BASELINE_ALERT_THRESHOLD_PCT", "10")))
+    parser.add_argument("--latency-threshold-pct", type=float, default=float(os.environ.get("FALCONFS_BASELINE_LATENCY_ALERT_THRESHOLD_PCT", "10")))
+    parser.add_argument("--latency-alert-enabled", default=os.environ.get("FALCONFS_BASELINE_LATENCY_ALERT_ENABLED", "1"))
     args = parser.parse_args()
 
     args.current_dir = str(Path(args.current_dir).resolve())
-    args.confirm_dir = str(Path(args.confirm_dir).resolve()) if args.confirm_dir else ""
-    threshold = args.threshold_pct / 100.0
+    throughput_threshold = args.threshold_pct / 100.0
+    latency_threshold = args.latency_threshold_pct / 100.0
+    latency_alert_enabled = args.latency_alert_enabled == "1"
 
     current_summary = read_summary(args.current_dir)
     if not current_summary:
         raise SystemExit(f"missing or empty summary.csv in {args.current_dir}")
 
-    confirm_summary = read_summary(args.confirm_dir) if args.confirm_dir else None
-    history = load_history(args.result_root, [args.current_dir, args.confirm_dir], args.history_window)
+    history = load_history(args.result_root, [args.current_dir], args.history_window)
     baseline = build_baseline(history, current_summary.keys(), args.min_history)
-    primary_results = compare(current_summary, baseline, threshold)
-    confirm_results = compare(confirm_summary, baseline, threshold) if confirm_summary else None
-    status, report = build_report(args, current_summary, history, baseline, primary_results, confirm_summary, confirm_results)
-    subject = write_outputs(args.current_dir, status, report)
+    throughput_results = compare_throughput(current_summary, baseline, throughput_threshold)
+    latency_results = compare_latency(current_summary, baseline, latency_threshold, latency_alert_enabled)
+    status, report = build_report(args, history, throughput_results, latency_results)
+    subject = write_outputs(args.current_dir, status, report, throughput_results, latency_results)
 
     sent = send_mail(subject, report)
     print(f"baseline report status: {status}")
@@ -301,8 +378,6 @@ def main():
     else:
         print("email not sent (set FALCONFS_BASELINE_MAIL_ENABLED=1 and SMTP env vars to enable)")
 
-    if status == "SUSPECT":
-        raise SystemExit(ALERT_EXIT_CODE)
     if status == "ALERT":
         raise SystemExit(ALERT_EXIT_CODE)
 

--- a/tests/private-directory-test/local-run.sh
+++ b/tests/private-directory-test/local-run.sh
@@ -1,52 +1,110 @@
 #!/bin/bash
+set -eo pipefail
 
-BIN_DIR="/root/falconfs/build/tests/private-directory-test"
-TEST_PROGRAM="test_falcon" # test_falcon / test_posix
-MOUNT_DIR="/test/" # meta directory / falconfs mount path, end with /
-FILE_PER_THREAD=1000
-PORT=1111
-FILE_SIZE=1572864
-CLIENT_NUM=1
-THREAD_NUM_PER_CLIENT=2000
-ROUND_INDEX=(0 1 2 3)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+BIN_DIR="${BIN_DIR:-/root/falconfs/build/tests/private-directory-test}"
+TEST_PROGRAM="${TEST_PROGRAM:-test_falcon}" # test_falcon / test_posix
+MOUNT_DIR="${MOUNT_DIR:-/test/}" # meta directory / falconfs mount path, end with /
+FILE_PER_THREAD="${FILE_PER_THREAD:-1000}"
+PORT="${PORT:-1111}"
+FILE_SIZE="${FILE_SIZE:-1572864}"
+CLIENT_NUM="${CLIENT_NUM:-1}"
+THREAD_NUM_PER_CLIENT="${THREAD_NUM_PER_CLIENT:-2000}"
+ROUND_INDEX="${ROUND_INDEX:-0 1 2 3}"
 ROUND_NAME=("workload_init" "workload_create" "workload_stat" "workload_open" "workload_close" "workload_delete" "workload_mkdir" "workload_rmdir" "workload_open_write_close" "workload_open_write_close_nocreate" "workload_open_read_close" "workload_kv_put" "workload_kv_get" "workload_kv_del" "workload_slice_put" "workload_slice_get" "workload_slice_del" "workload_uninit")
-CLIENT_ID=0
-MOUNT_PER_CLIENT=1
-CLIENT_CACHE_SIZE=16384
-META_SERVER_IP="127.0.0.1" # meta cn ip
-META_SERVER_PORT="58610" #meta cn port
+CLIENT_ID="${CLIENT_ID:-0}"
+MOUNT_PER_CLIENT="${MOUNT_PER_CLIENT:-1}"
+CLIENT_CACHE_SIZE="${CLIENT_CACHE_SIZE:-16384}"
+META_SERVER_IP="${META_SERVER_IP:-127.0.0.1}" # meta cn ip
+META_SERVER_PORT="${META_SERVER_PORT:-58610}" # meta cn port
+SIGNAL_IP="${SIGNAL_IP:-127.0.0.1}"
+POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-3}"
+ROUND_TIMEOUT_SEC="${ROUND_TIMEOUT_SEC:-0}"
+RUN_ID="${RUN_ID:-$(date +%Y%m%d_%H%M%S)}"
+RESULT_ROOT="${RESULT_ROOT:-$SCRIPT_DIR/results}"
+RESULT_DIR="${RESULT_DIR:-$RESULT_ROOT/$RUN_ID}"
+SUMMARY_FILE="${SUMMARY_FILE:-$RESULT_DIR/summary.csv}"
 
-echo "Thread Num" $(($THREAD_NUM_PER_CLIENT * $CLIENT_NUM))", Files per Thread" $FILE_PER_THREAD
+read -r -a ROUND_INDEX_ARRAY <<< "$ROUND_INDEX"
 
-for round_idx in "${ROUND_INDEX[@]}"
+extract_finish_field() {
+    local line="$1"
+    local field="$2"
+
+    printf '%s\n' "$line" | awk -v key="$field" -F', ' '{
+        prefix = key " "
+        for (i = 1; i <= NF; i++) {
+            if (index($i, prefix) == 1) {
+                print substr($i, length(prefix) + 1)
+                exit
+            }
+        }
+    }'
+}
+
+program_path="$BIN_DIR/$TEST_PROGRAM"
+if [ ! -x "$program_path" ]; then
+    echo "Error: test program is not executable: $program_path" >&2
+    exit 1
+fi
+
+mkdir -p "$RESULT_DIR"
+printf 'round_idx,round_name,throughput,avg_latency,ops,time,raw_log\n' > "$SUMMARY_FILE"
+
+echo "Thread Num $((THREAD_NUM_PER_CLIENT * CLIENT_NUM)), Files per Thread $FILE_PER_THREAD"
+echo "Result dir: $RESULT_DIR"
+
+for round_idx in "${ROUND_INDEX_ARRAY[@]}"
 do
-    SERVER_IP=$META_SERVER_IP SERVER_PORT=$META_SERVER_PORT LD_LIBRARY_PATH=/usr/local/lib64/:$LD_LIBRARY_PATH $BIN_DIR/$TEST_PROGRAM $MOUNT_DIR $FILE_PER_THREAD $THREAD_NUM_PER_CLIENT $round_idx $CLIENT_ID $MOUNT_PER_CLIENT $CLIENT_CACHE_SIZE $PORT $FILE_SIZE $CLIENT_NUM > $BIN_DIR/result_1111 2>&1 &
-    sleep 1
-    python3 send_signal.py 127.0.0.1 $PORT
+    round_name="${ROUND_NAME[$round_idx]}"
+    raw_log="$RESULT_DIR/round_${round_idx}_${round_name}.log"
 
+    SERVER_IP=$META_SERVER_IP \
+    SERVER_PORT=$META_SERVER_PORT \
+    LD_LIBRARY_PATH="/usr/local/lib64/:${LD_LIBRARY_PATH:-}" \
+    "$program_path" "$MOUNT_DIR" "$FILE_PER_THREAD" "$THREAD_NUM_PER_CLIENT" "$round_idx" "$CLIENT_ID" "$MOUNT_PER_CLIENT" "$CLIENT_CACHE_SIZE" "$PORT" "$FILE_SIZE" "$CLIENT_NUM" > "$raw_log" 2>&1 &
+    test_pid=$!
+
+    sleep 1
+    python3 "$SCRIPT_DIR/send_signal.py" "$SIGNAL_IP" "$PORT"
+
+    elapsed=0
     while true
     do
-        sleep 3
-        total_throughput=0
-        if [ -f "$BIN_DIR/result_1111" ]; then
-            last_line=$(awk 'NF{line=$0} END{print line}' "$BIN_DIR/result_1111")
+        sleep "$POLL_INTERVAL_SEC"
+        elapsed=$((elapsed + POLL_INTERVAL_SEC))
+        if [ -f "$raw_log" ]; then
+            last_line=$(awk 'NF{line=$0} END{print line}' "$raw_log")
             if [[ $last_line == *"[FINISH]"* ]]; then
-                throughput=$(echo "$last_line" | awk -F', ' '{
-                    for(i=1;i<=NF;i++){
-                        if($i~/^Throughput/){
-                            split($i,a," ")
-                            print a[2]
-                        }
-                    }
-                }')
+                throughput=$(extract_finish_field "$last_line" "Throughput")
+                avg_latency=$(extract_finish_field "$last_line" "Average Latency")
+                ops=$(extract_finish_field "$last_line" "OPs")
+                time_spent=$(extract_finish_field "$last_line" "Time")
                 if [ -z "$throughput" ]; then
                     continue
                 fi
-                total_throughput=$(echo "$total_throughput + $throughput" | bc)
+                printf '%s,%s,%s,%s,%s,%s,%s\n' "$round_idx" "$round_name" "$throughput" "$avg_latency" "$ops" "$time_spent" "$raw_log" >> "$SUMMARY_FILE"
                 break
-                rm -f "./result_${SERVER}_${PORT}"
             fi
         fi
+
+        if ! kill -0 "$test_pid" 2>/dev/null; then
+            wait "$test_pid" || true
+            echo "Error: round $round_idx ($round_name) exited without a [FINISH] line; see $raw_log" >&2
+            exit 1
+        fi
+
+        if [ "$ROUND_TIMEOUT_SEC" -gt 0 ] && [ "$elapsed" -ge "$ROUND_TIMEOUT_SEC" ]; then
+            kill "$test_pid" 2>/dev/null || true
+            wait "$test_pid" 2>/dev/null || true
+            echo "Error: round $round_idx ($round_name) timed out after ${ROUND_TIMEOUT_SEC}s; see $raw_log" >&2
+            exit 1
+        fi
     done
-    echo "round" ${ROUND_NAME[$round_idx]} "done, total throughput =" $total_throughput
+
+    wait "$test_pid"
+    echo "round $round_name done, total throughput = $throughput"
 done
+
+echo "Summary file: $SUMMARY_FILE"

--- a/tests/private-directory-test/run_daily_baseline.sh
+++ b/tests/private-directory-test/run_daily_baseline.sh
@@ -20,9 +20,9 @@ TEST_DIR="$INSTALL_DIR/private-directory-test"
 ROUNDS="${FALCONFS_BASELINE_ROUNDS:-0 1 2 3}"
 SUDO_CMD_TEXT="${FALCONFS_BASELINE_SUDO_CMD:-sudo -n}"
 REPORT_ENABLED="${FALCONFS_BASELINE_REPORT:-1}"
-CONFIRM_ON_DEGRADATION="${FALCONFS_BASELINE_CONFIRM_ON_DEGRADATION:-1}"
 FAIL_ON_ALERT="${FALCONFS_BASELINE_FAIL_ON_ALERT:-0}"
-REPORT_SCRIPT="${FALCONFS_BASELINE_REPORT_SCRIPT:-$TEST_DIR/baseline_report.py}"
+REPORT_SCRIPT="${FALCONFS_BASELINE_REPORT_SCRIPT:-$SCRIPT_DIR/baseline_report.py}"
+ITERATIONS="${FALCONFS_BASELINE_ITERATIONS:-3}"
 
 read -r -a SUDO_CMD <<< "$SUDO_CMD_TEXT"
 
@@ -73,7 +73,6 @@ run_private_directory_baseline() {
 
 run_baseline_report() {
     local current_dir="$1"
-    local confirm_dir="${2:-}"
     local script_path="$REPORT_SCRIPT"
 
     if [ ! -x "$script_path" ]; then
@@ -89,15 +88,115 @@ run_baseline_report() {
         --result-root "$RESULT_ROOT"
         --current-dir "$current_dir"
     )
-    if [ -n "$confirm_dir" ]; then
-        report_args+=(--confirm-dir "$confirm_dir")
-    fi
 
     set +e
     python3 "${report_args[@]}"
     local status=$?
     set -e
     return "$status"
+}
+
+aggregate_iteration_summaries() {
+    python3 - "$RESULT_DIR" "$ITERATIONS" <<'PY'
+import csv
+import sys
+from pathlib import Path
+
+result_dir = Path(sys.argv[1])
+iterations = int(sys.argv[2])
+rows = {}
+
+for idx in range(1, iterations + 1):
+    summary = result_dir / f"iter_{idx}" / "summary.csv"
+    if not summary.is_file():
+        raise SystemExit(f"missing iteration summary: {summary}")
+
+    with summary.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row.get("round_name", "")
+            if not name:
+                continue
+            item = rows.setdefault(name, {
+                "round_idx": row.get("round_idx", ""),
+                "round_name": name,
+                "throughput": [],
+                "avg_latency": [],
+                "ops": [],
+                "time": [],
+                "raw_log": [],
+            })
+
+            for key in ("throughput", "ops", "time"):
+                value = row.get(key, "")
+                try:
+                    item[key].append(float(value))
+                except ValueError:
+                    pass
+
+            try:
+                latency = float(row.get("avg_latency", ""))
+                if latency > 0:
+                    item["avg_latency"].append(latency)
+            except ValueError:
+                pass
+
+            raw_log = row.get("raw_log", "")
+            if raw_log:
+                item["raw_log"].append(raw_log)
+
+def avg(values):
+    return sum(values) / len(values) if values else ""
+
+output = result_dir / "summary.csv"
+with output.open("w", newline="", encoding="utf-8") as f:
+    fieldnames = ["round_idx", "round_name", "throughput", "avg_latency", "ops", "time", "iterations", "raw_log"]
+    writer = csv.DictWriter(f, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in sorted(rows.values(), key=lambda item: int(item["round_idx"])):
+        writer.writerow({
+            "round_idx": row["round_idx"],
+            "round_name": row["round_name"],
+            "throughput": avg(row["throughput"]),
+            "avg_latency": avg(row["avg_latency"]),
+            "ops": avg(row["ops"]),
+            "time": avg(row["time"]),
+            "iterations": iterations,
+            "raw_log": ";".join(row["raw_log"]),
+        })
+PY
+}
+
+write_host_info() {
+    local host_info_file="$RESULT_DIR/host_info.txt"
+    local primary_ip=""
+    primary_ip=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+    local cpu_model=""
+    cpu_model=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo 2>/dev/null || true)
+    local mem_total=""
+    mem_total=$(awk '/MemTotal/{print $2 " " $3}' /proc/meminfo 2>/dev/null || true)
+    local os_release=""
+    os_release=$(grep '^PRETTY_NAME=' /etc/os-release 2>/dev/null | cut -d= -f2- | tr -d '"' || true)
+
+    {
+        printf 'hostname=%s\n' "$(hostname 2>/dev/null || true)"
+        printf 'primary_ip=%s\n' "$primary_ip"
+        printf 'user=%s\n' "$(id -un)"
+        printf 'repo_dir=%s\n' "$REPO_DIR"
+        printf 'result_dir=%s\n' "$RESULT_DIR"
+        printf 'install_dir=%s\n' "$INSTALL_DIR"
+        printf 'kernel=%s\n' "$(uname -srmo 2>/dev/null || true)"
+        printf 'os_release=%s\n' "$os_release"
+        printf 'cpu_model=%s\n' "$cpu_model"
+        printf 'cpu_count=%s\n' "$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+        printf 'mem_total=%s\n' "$mem_total"
+        printf 'rounds=%s\n' "$ROUNDS"
+        printf 'iterations=%s\n' "$ITERATIONS"
+        printf 'file_per_thread=%s\n' "${FALCONFS_BASELINE_FILE_PER_THREAD:-1000}"
+        printf 'thread_num_per_client=%s\n' "${FALCONFS_BASELINE_THREAD_NUM_PER_CLIENT:-2000}"
+        printf 'client_num=%s\n' "${FALCONFS_BASELINE_CLIENT_NUM:-1}"
+        printf 'file_size=%s\n' "${FALCONFS_BASELINE_FILE_SIZE:-1572864}"
+    } > "$host_info_file"
 }
 
 mkdir -p "$RESULT_DIR"
@@ -143,29 +242,49 @@ git_dirty=$git_dirty
 git_status_file=$git_status_file
 baseline_ref=$BASELINE_REF
 result_dir=$RESULT_DIR
+host_info_file=$RESULT_DIR/host_info.txt
+iterations=$ITERATIONS
+rounds=$ROUNDS
+file_per_thread=${FALCONFS_BASELINE_FILE_PER_THREAD:-1000}
+thread_num_per_client=${FALCONFS_BASELINE_THREAD_NUM_PER_CLIENT:-2000}
+client_num=${FALCONFS_BASELINE_CLIENT_NUM:-1}
+file_size=${FALCONFS_BASELINE_FILE_SIZE:-1572864}
 EOF
-
-if [ "$RUN_BUILD" = "1" ]; then
-    log "Cleaning FalconFS build"
-    ./build.sh clean falcon
-    log "Building FalconFS"
-    ./build.sh build falcon
-    log "Installing FalconFS to $INSTALL_DIR"
-    "${SUDO_CMD[@]}" ./build.sh install falcon
-fi
-
-if [ "$RUN_DEPLOY" = "1" ]; then
-    log "Stopping FalconFS"
-    ./deploy/falcon_stop.sh
-    log "Starting FalconFS"
-    ./deploy/falcon_start.sh
-fi
 
 meta_server_ip="${FALCONFS_BASELINE_META_SERVER_IP:-$(resolve_meta_server_ip)}"
 meta_server_port="${FALCONFS_BASELINE_META_SERVER_PORT:-$(resolve_meta_server_port)}"
+write_host_info
 
-log "Running private-directory baseline rounds: $ROUNDS"
-run_private_directory_baseline "$RESULT_DIR" "$RUN_ID"
+for ((iteration = 1; iteration <= ITERATIONS; iteration++)); do
+    iteration_run_id="${RUN_ID}_iter_${iteration}"
+    iteration_dir="$RESULT_DIR/iter_${iteration}"
+
+    log "Starting iteration $iteration/$ITERATIONS"
+    if [ "$RUN_DEPLOY" = "1" ]; then
+        log "Stopping FalconFS for iteration $iteration"
+        ./deploy/falcon_stop.sh
+    fi
+
+    if [ "$RUN_BUILD" = "1" ]; then
+        log "Cleaning FalconFS build for iteration $iteration"
+        ./build.sh clean falcon
+        log "Building FalconFS for iteration $iteration"
+        ./build.sh build falcon
+        log "Installing FalconFS to $INSTALL_DIR for iteration $iteration"
+        "${SUDO_CMD[@]}" ./build.sh install falcon
+    fi
+
+    if [ "$RUN_DEPLOY" = "1" ]; then
+        log "Starting FalconFS for iteration $iteration"
+        ./deploy/falcon_start.sh
+    fi
+
+    log "Running private-directory baseline rounds for iteration $iteration: $ROUNDS"
+    run_private_directory_baseline "$iteration_dir" "$iteration_run_id"
+done
+
+log "Aggregating $ITERATIONS iteration summaries"
+aggregate_iteration_summaries
 
 if [ "$REPORT_ENABLED" = "1" ]; then
     log "Generating baseline report"
@@ -176,29 +295,7 @@ if [ "$REPORT_ENABLED" = "1" ]; then
     if [ "$report_status" -ne 0 ] && [ "$report_status" -ne 10 ]; then
         exit "$report_status"
     fi
-    if [ "$report_status" -eq 10 ] && [ "$CONFIRM_ON_DEGRADATION" = "1" ]; then
-        CONFIRM_RUN_ID="${RUN_ID}_confirm"
-        CONFIRM_RESULT_DIR="${RESULT_DIR}_confirm"
-        log "Suspected degradation detected; rerunning benchmark only for confirmation"
-        run_private_directory_baseline "$CONFIRM_RESULT_DIR" "$CONFIRM_RUN_ID"
-        cat >> "$CONFIRM_RESULT_DIR/run_info.env" <<EOF
-confirm_of=$RUN_ID
-confirm_of_result_dir=$RESULT_DIR
-EOF
-        set +e
-        run_baseline_report "$RESULT_DIR" "$CONFIRM_RESULT_DIR"
-        final_report_status=$?
-        set -e
-        if [ "$final_report_status" -ne 0 ] && [ "$final_report_status" -ne 10 ]; then
-            exit "$final_report_status"
-        fi
-        if [ "$final_report_status" -eq 10 ]; then
-            log "Confirmed baseline degradation"
-            if [ "$FAIL_ON_ALERT" = "1" ]; then
-                exit 10
-            fi
-        fi
-    elif [ "$report_status" -eq 10 ] && [ "$FAIL_ON_ALERT" = "1" ]; then
+    if [ "$report_status" -eq 10 ] && [ "$FAIL_ON_ALERT" = "1" ]; then
         exit 10
     fi
 fi

--- a/tests/private-directory-test/run_daily_baseline.sh
+++ b/tests/private-directory-test/run_daily_baseline.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+REPO_DIR="${FALCONFS_BASELINE_REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd -P)}"
+RESULT_ROOT="${FALCONFS_BASELINE_RESULT_ROOT:-$HOME/falconfs-baseline-results}"
+RUN_ID="${FALCONFS_BASELINE_RUN_ID:-$(date +%Y%m%d_%H%M%S)}"
+RESULT_DIR="${FALCONFS_BASELINE_RESULT_DIR:-$RESULT_ROOT/$RUN_ID}"
+LOCK_DIR="${FALCONFS_BASELINE_LOCK_DIR:-/tmp/falconfs_daily_baseline_$(id -un).lockdir}"
+
+BASELINE_BRANCH="${FALCONFS_BASELINE_BRANCH:-baseline/upstream-main}"
+BASELINE_REMOTE="${FALCONFS_BASELINE_REMOTE:-upstream}"
+BASELINE_REF="${FALCONFS_BASELINE_REF:-$BASELINE_REMOTE/main}"
+UPDATE_GIT="${FALCONFS_BASELINE_UPDATE_GIT:-1}"
+ALLOW_BRANCH_RESET="${FALCONFS_BASELINE_ALLOW_BRANCH_RESET:-0}"
+RUN_BUILD="${FALCONFS_BASELINE_BUILD:-1}"
+RUN_DEPLOY="${FALCONFS_BASELINE_DEPLOY:-1}"
+INSTALL_DIR="${FALCONFS_INSTALL_DIR:-/usr/local/falconfs}"
+TEST_DIR="$INSTALL_DIR/private-directory-test"
+ROUNDS="${FALCONFS_BASELINE_ROUNDS:-0 1 2 3}"
+SUDO_CMD_TEXT="${FALCONFS_BASELINE_SUDO_CMD:-sudo -n}"
+REPORT_ENABLED="${FALCONFS_BASELINE_REPORT:-1}"
+CONFIRM_ON_DEGRADATION="${FALCONFS_BASELINE_CONFIRM_ON_DEGRADATION:-1}"
+FAIL_ON_ALERT="${FALCONFS_BASELINE_FAIL_ON_ALERT:-0}"
+REPORT_SCRIPT="${FALCONFS_BASELINE_REPORT_SCRIPT:-$TEST_DIR/baseline_report.py}"
+
+read -r -a SUDO_CMD <<< "$SUDO_CMD_TEXT"
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+resolve_meta_server_ip() {
+    local meta_config="$REPO_DIR/deploy/meta/falcon_meta_config.sh"
+    if [ -f "$meta_config" ]; then
+        bash -lc "source '$meta_config' >/dev/null 2>&1; printf '%s' \"\${cnIp:-127.0.0.1}\""
+    else
+        printf '127.0.0.1'
+    fi
+}
+
+resolve_meta_server_port() {
+    local meta_config="$REPO_DIR/deploy/meta/falcon_meta_config.sh"
+    if [ -f "$meta_config" ]; then
+        bash -lc "source '$meta_config' >/dev/null 2>&1; printf '%s0' \"\${cnPoolerPortPrefix:-5551}\""
+    else
+        printf '55510'
+    fi
+}
+
+run_private_directory_baseline() {
+    local output_dir="$1"
+    local run_id="$2"
+
+    BIN_DIR="$TEST_DIR/bin" \
+    TEST_PROGRAM="${FALCONFS_BASELINE_TEST_PROGRAM:-test_falcon}" \
+    MOUNT_DIR="${FALCONFS_BASELINE_MOUNT_DIR:-/}" \
+    FILE_PER_THREAD="${FALCONFS_BASELINE_FILE_PER_THREAD:-1000}" \
+    THREAD_NUM_PER_CLIENT="${FALCONFS_BASELINE_THREAD_NUM_PER_CLIENT:-2000}" \
+    ROUND_INDEX="$ROUNDS" \
+    PORT="${FALCONFS_BASELINE_WAIT_PORT:-1111}" \
+    FILE_SIZE="${FALCONFS_BASELINE_FILE_SIZE:-1572864}" \
+    CLIENT_NUM="${FALCONFS_BASELINE_CLIENT_NUM:-1}" \
+    CLIENT_ID="${FALCONFS_BASELINE_CLIENT_ID:-0}" \
+    MOUNT_PER_CLIENT="${FALCONFS_BASELINE_MOUNT_PER_CLIENT:-1}" \
+    CLIENT_CACHE_SIZE="${FALCONFS_BASELINE_CLIENT_CACHE_SIZE:-16384}" \
+    META_SERVER_IP="$meta_server_ip" \
+    META_SERVER_PORT="$meta_server_port" \
+    RESULT_DIR="$output_dir" \
+    RUN_ID="$run_id" \
+    bash "$TEST_DIR/local-run.sh"
+}
+
+run_baseline_report() {
+    local current_dir="$1"
+    local confirm_dir="${2:-}"
+    local script_path="$REPORT_SCRIPT"
+
+    if [ ! -x "$script_path" ]; then
+        script_path="$SCRIPT_DIR/baseline_report.py"
+    fi
+    if [ ! -x "$script_path" ]; then
+        log "Baseline report script not found, skip report"
+        return 0
+    fi
+
+    local report_args=(
+        "$script_path"
+        --result-root "$RESULT_ROOT"
+        --current-dir "$current_dir"
+    )
+    if [ -n "$confirm_dir" ]; then
+        report_args+=(--confirm-dir "$confirm_dir")
+    fi
+
+    set +e
+    python3 "${report_args[@]}"
+    local status=$?
+    set -e
+    return "$status"
+}
+
+mkdir -p "$RESULT_DIR"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo "Another FalconFS daily baseline run is already active: $LOCK_DIR" >&2
+    exit 1
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+cd "$REPO_DIR"
+
+if [ "$UPDATE_GIT" = "1" ]; then
+    current_branch=$(git branch --show-current)
+    if [ "$current_branch" != "$BASELINE_BRANCH" ] && [ "$ALLOW_BRANCH_RESET" != "1" ]; then
+        cat >&2 <<EOF
+Refusing to reset branch '$current_branch'.
+Run this script from the dedicated '$BASELINE_BRANCH' worktree, or set FALCONFS_BASELINE_ALLOW_BRANCH_RESET=1.
+EOF
+        exit 1
+    fi
+
+    log "Fetching $BASELINE_REMOTE"
+    git fetch "$BASELINE_REMOTE"
+    log "Resetting $current_branch to $BASELINE_REF"
+    git reset --hard "$BASELINE_REF"
+fi
+
+commit_sha=$(git rev-parse HEAD)
+commit_subject=$(git log -1 --format=%s)
+git_status_file="$RESULT_DIR/git_status.txt"
+git status --short --branch > "$git_status_file"
+git_dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+    git_dirty=1
+fi
+
+cat > "$RESULT_DIR/run_info.env" <<EOF
+run_id=$RUN_ID
+repo_dir=$REPO_DIR
+commit_sha=$commit_sha
+commit_subject=$commit_subject
+git_dirty=$git_dirty
+git_status_file=$git_status_file
+baseline_ref=$BASELINE_REF
+result_dir=$RESULT_DIR
+EOF
+
+if [ "$RUN_BUILD" = "1" ]; then
+    log "Cleaning FalconFS build"
+    ./build.sh clean falcon
+    log "Building FalconFS"
+    ./build.sh build falcon
+    log "Installing FalconFS to $INSTALL_DIR"
+    "${SUDO_CMD[@]}" ./build.sh install falcon
+fi
+
+if [ "$RUN_DEPLOY" = "1" ]; then
+    log "Stopping FalconFS"
+    ./deploy/falcon_stop.sh
+    log "Starting FalconFS"
+    ./deploy/falcon_start.sh
+fi
+
+meta_server_ip="${FALCONFS_BASELINE_META_SERVER_IP:-$(resolve_meta_server_ip)}"
+meta_server_port="${FALCONFS_BASELINE_META_SERVER_PORT:-$(resolve_meta_server_port)}"
+
+log "Running private-directory baseline rounds: $ROUNDS"
+run_private_directory_baseline "$RESULT_DIR" "$RUN_ID"
+
+if [ "$REPORT_ENABLED" = "1" ]; then
+    log "Generating baseline report"
+    set +e
+    run_baseline_report "$RESULT_DIR"
+    report_status=$?
+    set -e
+    if [ "$report_status" -ne 0 ] && [ "$report_status" -ne 10 ]; then
+        exit "$report_status"
+    fi
+    if [ "$report_status" -eq 10 ] && [ "$CONFIRM_ON_DEGRADATION" = "1" ]; then
+        CONFIRM_RUN_ID="${RUN_ID}_confirm"
+        CONFIRM_RESULT_DIR="${RESULT_DIR}_confirm"
+        log "Suspected degradation detected; rerunning benchmark only for confirmation"
+        run_private_directory_baseline "$CONFIRM_RESULT_DIR" "$CONFIRM_RUN_ID"
+        cat >> "$CONFIRM_RESULT_DIR/run_info.env" <<EOF
+confirm_of=$RUN_ID
+confirm_of_result_dir=$RESULT_DIR
+EOF
+        set +e
+        run_baseline_report "$RESULT_DIR" "$CONFIRM_RESULT_DIR"
+        final_report_status=$?
+        set -e
+        if [ "$final_report_status" -ne 0 ] && [ "$final_report_status" -ne 10 ]; then
+            exit "$final_report_status"
+        fi
+        if [ "$final_report_status" -eq 10 ]; then
+            log "Confirmed baseline degradation"
+            if [ "$FAIL_ON_ALERT" = "1" ]; then
+                exit 10
+            fi
+        fi
+    elif [ "$report_status" -eq 10 ] && [ "$FAIL_ON_ALERT" = "1" ]; then
+        exit 10
+    fi
+fi
+
+log "Daily baseline completed: $RESULT_DIR"

--- a/tests/private-directory-test/run_daily_baseline.sh
+++ b/tests/private-directory-test/run_daily_baseline.sh
@@ -8,9 +8,9 @@ RUN_ID="${FALCONFS_BASELINE_RUN_ID:-$(date +%Y%m%d_%H%M%S)}"
 RESULT_DIR="${FALCONFS_BASELINE_RESULT_DIR:-$RESULT_ROOT/$RUN_ID}"
 LOCK_DIR="${FALCONFS_BASELINE_LOCK_DIR:-/tmp/falconfs_daily_baseline_$(id -un).lockdir}"
 
-BASELINE_BRANCH="${FALCONFS_BASELINE_BRANCH:-baseline/upstream-main}"
-BASELINE_REMOTE="${FALCONFS_BASELINE_REMOTE:-upstream}"
-BASELINE_REF="${FALCONFS_BASELINE_REF:-$BASELINE_REMOTE/main}"
+BASELINE_BRANCH="${FALCONFS_BASELINE_BRANCH:-baseline/main}"
+BASELINE_GIT_URL="${FALCONFS_BASELINE_GIT_URL:-https://github.com/falcon-infra/falconfs.git}"
+BASELINE_GIT_REF="${FALCONFS_BASELINE_GIT_REF:-main}"
 UPDATE_GIT="${FALCONFS_BASELINE_UPDATE_GIT:-1}"
 ALLOW_BRANCH_RESET="${FALCONFS_BASELINE_ALLOW_BRANCH_RESET:-0}"
 RUN_BUILD="${FALCONFS_BASELINE_BUILD:-1}"
@@ -218,10 +218,10 @@ EOF
         exit 1
     fi
 
-    log "Fetching $BASELINE_REMOTE"
-    git fetch "$BASELINE_REMOTE"
-    log "Resetting $current_branch to $BASELINE_REF"
-    git reset --hard "$BASELINE_REF"
+    log "Fetching $BASELINE_GIT_REF from $BASELINE_GIT_URL"
+    git fetch "$BASELINE_GIT_URL" "$BASELINE_GIT_REF"
+    log "Resetting $current_branch to FETCH_HEAD"
+    git reset --hard FETCH_HEAD
 fi
 
 commit_sha=$(git rev-parse HEAD)
@@ -240,7 +240,8 @@ commit_sha=$commit_sha
 commit_subject=$commit_subject
 git_dirty=$git_dirty
 git_status_file=$git_status_file
-baseline_ref=$BASELINE_REF
+baseline_git_url=$BASELINE_GIT_URL
+baseline_git_ref=$BASELINE_GIT_REF
 result_dir=$RESULT_DIR
 host_info_file=$RESULT_DIR/host_info.txt
 iterations=$ITERATIONS


### PR DESCRIPTION
## Summary
- Add a daily private-directory baseline runner that can update to `upstream/main`, build/install FalconFS, restart local deployment, and run rounds `0 1 2 3`.
- Make `local-run.sh` parameterizable and persist per-round raw logs plus `summary.csv` instead of overwriting a single result file.
- Add baseline reporting with recent-history median comparison, optional confirmation rerun, and SMTP email preview/sending support.
## Details
This adds a local daily performance baseline workflow for `tests/private-directory-test`.
The default benchmark still runs the metadata-focused rounds:
```text
0 workload_init
1 workload_create
2 workload_stat
3 workload_open
run_daily_baseline.sh handles the full daily flow:
git fetch upstream
git reset --hard upstream/main
./build.sh clean falcon
./build.sh build falcon
sudo -n ./build.sh install falcon
./deploy/falcon_stop.sh
./deploy/falcon_start.sh
local-run.sh
baseline_report.py compares the current run against the recent baseline history:
- Default history window: 7 runs
- Default minimum history: 3 runs
- Default alert threshold: 10% throughput drop
- Alert condition: any round degrades beyond the threshold
- Confirmation behavior: rerun benchmark once before marking confirmed degradation
Email sending is disabled by default. The report always writes:
baseline_report.txt
email_preview.txt
SMTP can be enabled through environment variables, with STARTTLS and internal SMTP CA handling documented.
Files Changed
- tests/private-directory-test/local-run.sh
  - Adds environment-variable overrides.
  - Writes timestamped result directories.
  - Emits summary.csv.
  - Uses script-relative send_signal.py.
  - Adds process failure and timeout handling.
- tests/private-directory-test/run_daily_baseline.sh
  - Adds daily orchestration for update/build/install/deploy/benchmark/report.
  - Protects non-runner branches from accidental reset.
  - Records run_info.env and git_status.txt.
  - Supports confirmation rerun on suspected degradation.
- tests/private-directory-test/baseline_report.py
  - Generates baseline reports from summary.csv.
  - Compares throughput against recent median history.
  - Generates email preview.
  - Supports optional SMTP sending.
- tests/private-directory-test/README.md
  - Documents local test usage.
  - Documents dedicated runner account setup.
  - Documents systemd timer setup.
  - Documents SMTP configuration and baseline result layout.
Validation
- Ran shell syntax checks for:
  - tests/private-directory-test/local-run.sh
  - tests/private-directory-test/run_daily_baseline.sh
- Ran Python syntax check for:
  - tests/private-directory-test/baseline_report.py
- Ran scoped whitespace checks for the changed private-directory-test files.
- Manually validated the runner flow with a reduced smoke workload.
- Verified SMTP report sending behavior with STARTTLS after disabling TLS certificate verification for internal SMTP gateways.
Notes
- Smoke runs should use a separate result root to avoid polluting daily baseline history.
- Formal nightly runs should keep the default full workload parameters and a stable FALCONFS_BASELINE_RESULT_ROOT.