### PR TITLE
fix: normalize PostgreSQL extension permissions

### DIFF
--- a/cloud_native/docker_build/cn/docker-entrypoint.sh
+++ b/cloud_native/docker_build/cn/docker-entrypoint.sh
@@ -52,7 +52,9 @@ if [ ! -d "${METADATA_DIR}" ]; then
     PG_LIB_DIR="${PG_PKG_LIB_DIR}"
     echo "Installing Falcon extension files to PostgreSQL system directories..."
     cp -f "${FALCONFS_INSTALL_DIR}"/falcon_meta/share/extension/falcon* "${PG_EXT_DIR}/" 2>/dev/null || true
+    chmod 644 "${PG_EXT_DIR}"/falcon* 2>/dev/null || true
     cp -f "${FALCONFS_INSTALL_DIR}"/falcon_meta/lib/postgresql/falcon*.so "${PG_LIB_DIR}/" 2>/dev/null || true
+    chmod 755 "${PG_LIB_DIR}"/falcon*.so 2>/dev/null || true
     echo "Falcon extension files installed."
 fi
 

--- a/cloud_native/docker_build/dn/docker-entrypoint.sh
+++ b/cloud_native/docker_build/dn/docker-entrypoint.sh
@@ -52,7 +52,9 @@ if [ ! -d "${METADATA_DIR}" ]; then
     PG_LIB_DIR="${PG_PKG_LIB_DIR}"
     echo "Installing Falcon extension files to PostgreSQL system directories..."
     cp -f "${FALCONFS_INSTALL_DIR}"/falcon_meta/share/extension/falcon* "${PG_EXT_DIR}/" 2>/dev/null || true
+    chmod 644 "${PG_EXT_DIR}"/falcon* 2>/dev/null || true
     cp -f "${FALCONFS_INSTALL_DIR}"/falcon_meta/lib/postgresql/falcon*.so "${PG_LIB_DIR}/" 2>/dev/null || true
+    chmod 755 "${PG_LIB_DIR}"/falcon*.so 2>/dev/null || true
 fi
 
 exec su -s /bin/bash falconMeta -c "bash ${STARTUP_SCRIPT} >${START_LOG_FILE} 2>&1"


### PR DESCRIPTION
## Summary
- Normalize Falcon PostgreSQL extension file permissions after copying them into PostgreSQL system directories.
- Set copied `falcon*` extension metadata files to `0644`.
- Set copied `falcon*.so` shared libraries to `0755` for CN/DN startup.
## Root Cause
In container environments with restrictive `umask` such as `0027`, `cp -f` may create `/usr/lib64/pgsql/falcon.so` as `0750` even when the source file is `0755`.
PostgreSQL is started as `falconMeta`, so it may fail to load the extension with:
```text
could not load library "/usr/lib64/pgsql/falcon.so": Permission denied
Fix
After copying Falcon extension files into PostgreSQL runtime directories, explicitly apply permissions:
- falcon* extension files: 0644
- falcon*.so shared libraries: 0755