### PR TITLE
fix: normalize deploy extension permissions

### DIFF
--- a/deploy/meta/falcon_meta_start.sh
+++ b/deploy/meta/falcon_meta_start.sh
@@ -17,7 +17,9 @@ install_falcon_extension() {
     echo "  Library files: $pg_lib_dir"
     sudo mkdir -p "$pg_ext_dir"
     sudo cp -f "$FALCONFS_INSTALL_DIR/falcon_meta/share/extension"/falcon* "$pg_ext_dir/" 2>/dev/null || true
+    sudo chmod 644 "$pg_ext_dir"/falcon* 2>/dev/null || true
     sudo cp -f "$FALCONFS_INSTALL_DIR/falcon_meta/lib/postgresql"/falcon*.so "$pg_lib_dir/" 2>/dev/null || true
+    sudo chmod 755 "$pg_lib_dir"/falcon*.so 2>/dev/null || true
 
     echo "Falcon extension files installed."
 }


### PR DESCRIPTION
Body
## Summary
- Normalize Falcon PostgreSQL extension permissions after copying files into PostgreSQL system directories.
- Set copied extension metadata files to `0644`.
- Set copied `falcon*.so` shared libraries to `0755` for both container and local deploy startup paths.
## Root Cause
When the runtime environment uses a restrictive `umask`, copied PostgreSQL extension files can inherit overly strict permissions.
For example:
- `umask=0027` can create `falcon.so` as `0750`.
- `umask=0077` can create `falcon.so` as `0700`.
PostgreSQL is started by non-root users such as `falconMeta` or the deploy user, so it may fail to load:
```text
/usr/lib64/pgsql/falcon.so: cannot open shared object file: Permission denied
Fix
After copying Falcon extension files into PostgreSQL runtime directories, explicitly normalize permissions:
- 
falcon* extension files: 0644
- 
falcon*.so shared libraries: 0755
Updated paths:
- 
deploy/meta/falcon_meta_start.sh