### PR TITLE
Add FalconFS task skills

### DIFF
--- a/.claude/skills/falcon-locking-transaction-review/SKILL.md
+++ b/.claude/skills/falcon-locking-transaction-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: falcon-locking-transaction-review
+description: Use this skill when changing or reviewing FalconFS locking correctness, lock release order, parent path locks, RWLock usage, dir_path_shmem, transaction cleanup, subtransaction abort callbacks, rename/mkdir concurrency, distributed metadata deadlock risks, InterruptHoldoffCount logic, spinlock interactions, or path protection invariants.
+---
+
+# Falcon Locking And Transaction Review
+
+Use this as a correctness gate for any lock or transaction change. Prefer finding behavioral regressions over style comments.
+
+## Built-In Context
+
+FalconFS metadata locking protects a replicated directory namespace in PostgreSQL shared memory. PostgreSQL backends are separate processes, so backend-local static lock bookkeeping is not global shared state. Path locks can span nested metadata work; cleanup must respect transaction and subtransaction ownership.
+
+For the focused checklist, read `references/locking-review-checklist.md`.
+
+## Core Invariants
+
+- Parent path locks must survive subtransaction abort when the parent operation still needs path protection.
+- Do not hold a spinlock while acquiring an RWLock.
+- Do not assume backend-local static lock state is shared across PostgreSQL processes.
+- Preserve lock acquisition order and release symmetry.
+- Do not introduce cleanup that can release another operation's locks.
+- Keep transaction/subtransaction nesting within FalconFS limits.
+- PostgreSQL interrupt holdoff changes must be balanced on every normal and error path; do not leave `InterruptHoldoffCount` elevated after cleanup.
+
+## Review Procedure
+
+1. Identify every lock acquired, released, or transferred by the change.
+2. Trace normal path, error path, transaction abort, and subtransaction abort separately.
+3. Check whether lock ownership is backend-local, shared-memory, per-request, or per-transaction.
+4. Check distributed operation behavior: mkdir, rename, and cross-server metadata paths need 2PC consistency.
+5. Look for hidden ordering changes between spinlocks, RWLocks, mutexes, and transaction cleanup.
+
+## Output Format
+
+Lead with findings. For each finding, include:
+
+- File and line when available.
+- The broken invariant.
+- Why the bug can happen.
+- A concrete fix or verification request.
+
+If no issue is found, say that clearly and list any concurrency scenarios that remain untested.

--- a/.claude/skills/falcon-locking-transaction-review/references/locking-review-checklist.md
+++ b/.claude/skills/falcon-locking-transaction-review/references/locking-review-checklist.md
@@ -1,0 +1,37 @@
+# Locking Review Checklist
+
+## Path Lock And Subtransaction Rules
+
+- Parent path locks are not ordinary subtransaction-local resources.
+- A subtransaction abort must not release path locks still required by the outer operation.
+- Cleanup must distinguish locks acquired by the failing subtransaction from locks owned by parent work.
+- Review `transaction/transaction.c` and `dir_path_shmem/dir_path_hash.c` together for path-lock changes.
+
+## Spinlock And RWLock Rules
+
+- Never acquire an RWLock while holding a spinlock.
+- Keep spinlock-held sections small and deterministic.
+- Do not call code that can allocate, block, log heavily, or raise PostgreSQL `ERROR` while holding a spinlock.
+
+## Ownership Questions
+
+- Who owns the lock: request, backend, transaction, subtransaction, or shared memory structure?
+- Can an error jump over the matching release?
+- Can cleanup run more than once?
+- Can cleanup release a lock acquired by a different nesting level?
+- Is the lock state stored in backend-local static memory, shared memory, or heap state?
+
+## Distributed Metadata Questions
+
+- Does the change affect mkdir, rename, unlink, or cross-server coordination?
+- Can one participant commit while another aborts?
+- Does cleanup interact with 2PC recovery or the cleanup daemon?
+- Are remote error paths preserving enough information to resolve in-doubt transactions?
+
+## Suggested Stress Scenarios
+
+- Concurrent mkdir and rename under the same parent.
+- Rename across metadata servers while one participant fails.
+- ERROR raised after child lock acquisition but before parent cleanup.
+- Subtransaction abort inside a larger metadata operation.
+- Repeated lock acquisition/release under high request batching.

--- a/.claude/skills/falcon-metadata-op-addition/SKILL.md
+++ b/.claude/skills/falcon-metadata-op-addition/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: falcon-metadata-op-addition
+description: Use this skill when adding, removing, or changing a FalconFS metadata operation or wire API across FlatBuffers schemas, falcon_client APIs, FUSE/POSIX mapping, router behavior, connection_pool dispatch, metadb operation handlers, distributed backend behavior, generated serialization code, or metadata service tests.
+---
+
+# Falcon Metadata Operation Addition
+
+Use this workflow when a metadata operation changes across layers. FalconFS metadata behavior often spans schema, client, routing, batching, PostgreSQL handlers, error mapping, and tests.
+
+## Built-In Context
+
+FalconFS metadata operations usually cross several layers: FUSE/POSIX client APIs, shard routing, FlatBuffers request/response schemas, connection-pool batching, PostgreSQL metadata handlers, distributed backend coordination, and error-code mapping. The metadata engine under `falcon/` is a PGXS-built PostgreSQL extension, while `falcon_client/` and storage/client libraries are CMake-built C++.
+
+If the operation changes locking or transaction behavior, use `falcon-locking-transaction-review`. If it changes PostgreSQL handler code, use `falcon-pg-extension-surgery`. For the layer-by-layer map, read `references/metadata-op-touchpoints.md`.
+
+## Classify The Operation
+
+- File operation: create, open, stat, read metadata, write metadata, truncate, unlink.
+- Directory operation: mkdir, rmdir, readdir, rename, path lookup.
+- Distributed operation: cross-server mkdir/rename or shard-affecting behavior.
+- Control operation: cluster, shard, server, or maintenance metadata.
+- Client-only mapping: POSIX/FUSE behavior without wire/schema change.
+
+## Required Trace
+
+Before editing, trace the operation through the relevant layers:
+
+1. Public client API in `falcon_client/src/falcon_meta.cpp`.
+2. Internal client/store bridge in `falcon_client/src/inner_falcon_meta.cpp` if data I/O is involved.
+3. Routing in `falcon_client/src/router.cpp`.
+4. Metadata connection and serialization in `falcon_client/src/connection.cpp`.
+5. FlatBuffers schema under `remote_connection_def/fbs/`.
+6. Server-side serialization helper in `falcon/metadb/meta_serialize_interface_helper.cpp`.
+7. Request batching/dispatch in `falcon/connection_pool/`.
+8. PostgreSQL metadata handler in `falcon/metadb/meta_handle.c`.
+9. Distributed backend in `falcon/distributed_backend/` if operation spans metadata servers.
+10. FUSE mapping in `falcon_client/fuse_main.cpp` if user-visible POSIX behavior changes.
+
+## Required Checks
+
+- Keep request and response schema versions compatible with generated code expectations.
+- Map Falcon error codes to POSIX `errno` when the operation reaches FUSE/client APIs.
+- Preserve retry behavior on `SERVER_FAULT` unless changing it intentionally.
+- Confirm directory operations update replicated directory namespace consistently.
+- Confirm file metadata operations use the correct shard/table path.
+- Add or update focused tests; if not feasible, name the exact missing test coverage.
+
+## Validation
+
+Use the smallest set that covers the touched layers:
+
+```bash
+./build.sh build falcon
+./build.sh test
+```
+
+For focused checks:
+
+```bash
+./build/tests/falcon/FalconQueueUT
+./build/tests/falcon_plugin/PluginFrameworkUT
+./build/tests/falcon_store/FalconStoreUT
+```
+
+Regenerate FlatBuffers or Protobuf outputs if the schema changes, following the existing build flow.

--- a/.claude/skills/falcon-metadata-op-addition/references/metadata-op-touchpoints.md
+++ b/.claude/skills/falcon-metadata-op-addition/references/metadata-op-touchpoints.md
@@ -1,0 +1,43 @@
+# Metadata Operation Touchpoints
+
+Use this file as a map, not a requirement to edit every file.
+
+## Client And FUSE
+
+- `falcon_client/fuse_main.cpp`: FUSE callbacks and POSIX-visible return conventions.
+- `falcon_client/src/falcon_meta.cpp`: public metadata API and retry behavior.
+- `falcon_client/src/inner_falcon_meta.cpp`: internal metadata/data operation bridge.
+- `falcon_client/src/router.cpp`: metadata server selection and shard routing.
+- `falcon_client/src/connection.cpp`: BRPC channel, FlatBuffers request/response handling.
+- `falcon_client/src/include/*.h`: public or internal API shape.
+
+## Wire Format And Generated Code
+
+- `remote_connection_def/fbs/`: metadata request/response schemas.
+- `remote_connection_def/proto/`: RPC service definitions when service shape changes.
+- `falcon/connection_pool/fbs/`: generated FlatBuffers headers used by metadata service.
+- `build/`: generated Protobuf output.
+
+## Metadata Engine
+
+- `falcon/metadb/meta_handle.c`: core metadata operation handlers.
+- `falcon/metadb/meta_serialize_interface_helper.cpp`: operation serialization and response helpers.
+- `falcon/metadb/*_table.c` and `falcon/include/metadb/*_table.h`: table-level operations.
+- `falcon/connection_pool/`: request batching, worker tasks, and dispatch.
+- `falcon/distributed_backend/`: 2PC and cross-server operation coordination.
+- `falcon/transaction/`: transaction wrappers and cleanup behavior.
+- `falcon/dir_path_shmem/`: replicated directory namespace and path locking.
+
+## Error Mapping
+
+- Check Falcon internal error code definitions under `falcon/include/` and `falcon/utils/`.
+- Check client-side `ErrorCodeToErrno()` before changing user-visible behavior.
+- Keep server errors precise enough for client retry and recovery decisions.
+
+## Test Locations
+
+- `tests/falcon/`: core metadata-adjacent unit tests.
+- `tests/falcon_plugin/`: plugin and metadata service framework tests.
+- `tests/falcon_meta_service_plugin/`: metadata service end-to-end plugin tests.
+- `tests/regress/`: Docker-based multi-node regression.
+- `tests/private-directory-test/`: workload and performance scenarios.

--- a/.claude/skills/falcon-pg-extension-surgery/SKILL.md
+++ b/.claude/skills/falcon-pg-extension-surgery/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: falcon-pg-extension-surgery
+description: Use this skill when modifying FalconFS PostgreSQL extension C code under falcon/, especially metadb/meta_handle.c handlers, PostgreSQL SPI/control functions, PGresult/PQclear cleanup, heap_freetuple cleanup, palloc memory contexts, transaction wrappers, snapshots/TOAST/PG17 behavior, background workers, or PGXS extension build issues.
+---
+
+# Falcon PG Extension Surgery
+
+Use this workflow for changes in `falcon/`. This code runs inside PostgreSQL backend processes, so ordinary C service assumptions are often wrong.
+
+## Built-In Context
+
+FalconFS metadata code under `falcon/` is a PostgreSQL extension built by PGXS, not by CMake. It runs inside PostgreSQL backend processes: each backend is single-threaded, while the whole service is multi-process. PostgreSQL memory contexts, `ERROR` unwinding, snapshots, SPI sessions, libpq results, and background-worker lifecycle rules apply.
+
+For detailed PG safety checks, read `references/pg-extension-safety-checklist.md`. If the change touches transactions, subtransactions, path locks, or cleanup callbacks, use `falcon-locking-transaction-review` too.
+
+## Classify The Change
+
+Identify the narrowest affected area before editing:
+
+- Metadata CRUD: `falcon/metadb/`, especially `meta_handle.c`.
+- SPI/control plane: `falcon/control/`.
+- Transactions and cleanup: `falcon/transaction/`.
+- Distributed metadata behavior: `falcon/distributed_backend/`.
+- Background workers and extension lifecycle: `falcon/falcon_init.c`, `falcon/plugin/`.
+- Communication adapter glue: `falcon/brpc_comm_adapter/`, `falcon/hcom_comm_adapter/`, `falcon/plugin_comm_adapter/`.
+
+## Required Checks
+
+- Match PG memory ownership: do not mix `palloc()`/`free()` or `malloc()`/`pfree()`.
+- Ensure `SPI_finish()`, `heap_freetuple()`, `PQclear()`, and allocated resources are handled on normal and error paths.
+- Use `PG_TRY`/`PG_CATCH`/`PG_FINALLY` when a PG `ERROR` can bypass cleanup.
+- Do not let C++ exceptions cross PostgreSQL C boundaries.
+- For PG17+ TOAST-backed table modifications, wrap the narrow operation that needs it with `PushActiveSnapshot(GetTransactionSnapshot())` and `PopActiveSnapshot()` in cleanup.
+- Keep subtransaction nesting below `MAX_SUB_XACT_DEPTH`.
+- Do not change lock lifetime or path-lock release rules without running the locking skill.
+- Remember `falcon/` is built by PGXS, not CMake.
+
+## Validation
+
+Prefer the smallest meaningful validation:
+
+```bash
+./build.sh build falcon
+./build.sh test
+```
+
+If only core unit tests are relevant:
+
+```bash
+./build/tests/falcon/FalconQueueUT
+./build/tests/falcon_plugin/PluginFrameworkUT
+./build/tests/falcon_plugin/PluginLoaderUT
+```
+
+If validation cannot run because the container or dependencies are missing, report that explicitly and explain what remains unverified.

--- a/.claude/skills/falcon-pg-extension-surgery/references/pg-extension-safety-checklist.md
+++ b/.claude/skills/falcon-pg-extension-surgery/references/pg-extension-safety-checklist.md
@@ -1,0 +1,47 @@
+# PG Extension Safety Checklist
+
+Use this checklist before finalizing changes under `falcon/`.
+
+## PostgreSQL Runtime Model
+
+- Code runs inside PostgreSQL backend processes.
+- Each backend is single-threaded, but the system is multi-process.
+- Backend-local static state is not shared across clients.
+- PostgreSQL `ERROR` unwinds control flow and can skip ordinary cleanup unless guarded.
+
+## Memory And Resource Ownership
+
+- Use `palloc()`/`pfree()` for PostgreSQL memory-context allocations.
+- Use `malloc()`/`free()` only for non-PG ownership and keep ownership obvious.
+- Do not return pointers into short-lived memory contexts.
+- Free heap tuples with `heap_freetuple()` when ownership requires it.
+- Clear libpq results with `PQclear()` on every path.
+- Finish SPI sessions with `SPI_finish()` even when later work errors.
+
+## Error Handling
+
+- Use `PG_TRY`/`PG_CATCH`/`PG_FINALLY` around code that must release locks, finish SPI, clear results, or restore state.
+- In `PG_CATCH`, perform cleanup and rethrow unless the caller intentionally converts the error.
+- Avoid swallowing PostgreSQL errors without preserving enough diagnostic context.
+
+## Snapshot And PG17 Rules
+
+- If modifying TOAST-backed relations or behavior that touches relation storage in PG17+, verify whether an active snapshot is required.
+- Use `PushActiveSnapshot(GetTransactionSnapshot())` immediately before the relation operation that requires an active snapshot, and `PopActiveSnapshot()` in guaranteed cleanup.
+- Keep the snapshot scope as small as possible. Do not leave an active snapshot across unrelated SPI, remote RPC, lock acquisition, or long-running work.
+- Track whether a snapshot was pushed so error cleanup does not call `PopActiveSnapshot()` without ownership.
+- Do not hold snapshots longer than needed.
+
+## Transactions And Subtransactions
+
+- Check `MAX_SUB_XACT_DEPTH` before adding nested subtransaction patterns.
+- Never release parent path locks on subtransaction abort.
+- Path-lock cleanup must distinguish locks acquired by the failing subtransaction from locks still owned by the outer metadata operation.
+- If a child operation fails, cleanup only the child-owned resources; parent path protection must remain until the parent operation finishes or aborts.
+- Treat transaction cleanup as correctness logic, not as generic best-effort cleanup.
+
+## Build-System Boundary
+
+- `falcon/` uses PGXS Makefiles.
+- `falcon/MakefilePlugin.brpc` and `falcon/MakefilePlugin.hcom` build communication plugins.
+- CMake changes do not fix metadata extension build failures unless the failure is in generated/shared dependencies.


### PR DESCRIPTION
## 修改概述

  新增 3 个面向 FalconFS 高风险开发场景的 Claude/Codex skills，用于沉淀仓库内常见任务流程、关键约束和审查清单，减少后续 AI 辅助开发时遗漏上下文或误改核心逻辑的风险。

  ## 修改内容

  - 新增 `falcon-pg-extension-surgery`
    - 面向 `falcon/` PostgreSQL extension 相关修改。
    - 覆盖 PG memory context、SPI 清理、`PGresult/PQclear`、`heap_freetuple`、snapshot/TOAST/PG17、background worker、PGXS 构建等检查点。

  - 新增 `falcon-locking-transaction-review`
    - 面向锁、事务、subtransaction、RWLock、path lock、deadlock 等并发正确性审查。
    - 强化 parent path lock、subtransaction abort、spinlock/RWLock 顺序、transaction cleanup 等关键约束。

  - 新增 `falcon-metadata-op-addition`
    - 面向新增或修改 metadata operation 的全链路开发。
    - 覆盖 FUSE/client、router、FlatBuffers schema、connection_pool、metadb handler、distributed backend、serialization code 和测试路径。

  ## 触发条件

  - 修改 `falcon/` 下 PostgreSQL extension C 代码时，触发 `falcon-pg-extension-surgery`。
  - 修改或 review 锁、事务、path lock、RWLock、subtransaction、rename/mkdir 并发逻辑时，触发 `falcon-locking-transaction-review`。
  - 新增、删除或修改 metadata operation / wire API，并涉及客户端、schema、调度、metadb 或分布式后端链路时，触发 `falcon-metadata-op-addition`。

  ## 设计说明

  这些 skill 以任务流程为主，不重复已有架构文档内容。详细检查项拆分到各自的 `references/` 文件中，保持 `SKILL.md` 简洁，同时在需要时提供更完整的审查清单。

  ## 测试说明

  本次修改仅新增 `.claude/skills/` 下的文档型 skill 文件，不涉及运行时代码、构建脚本或测试逻辑变更。