### PR TITLE
Fix FUSE utimens timestamp conversion

### DIFF
--- a/falcon_client/fuse_main.cpp
+++ b/falcon_client/fuse_main.cpp
@@ -5,8 +5,10 @@
 #define FUSE_USE_VERSION 26
 
 #include <execinfo.h>
+#include <cerrno>
 #include <cstring>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <atomic>
 #include <csignal>
@@ -30,6 +32,43 @@
 #endif
 
 static bool g_persist = false;
+
+static int64_t ConvertTimestampFromUnixToPG(const struct timespec &tv)
+{
+    // PostgreSQL TimestampTz is measured from 2000-01-01, while Unix time is measured from 1970-01-01.
+    // The epoch difference is 30 years plus 7 leap days: 10957 days * 24 * 60 * 60 = 946684800 seconds.
+    constexpr int64_t SECONDS_DIFF_BETWEEN_PG_AND_UNIX = 946684800;
+    constexpr int64_t USECS_PER_SEC = 1000000;
+    constexpr int64_t NSECS_PER_USEC = 1000;
+    return (static_cast<int64_t>(tv.tv_sec) - SECONDS_DIFF_BETWEEN_PG_AND_UNIX) * USECS_PER_SEC +
+           tv.tv_nsec / NSECS_PER_USEC;
+}
+
+static int ResolveUtimensTimestamp(const struct timespec tv[2],
+                                   int index,
+                                   const struct stat *oldStat,
+                                   int64_t *timestamp)
+{
+    if (tv[index].tv_nsec == UTIME_NOW) {
+        struct timespec now = {};
+        if (clock_gettime(CLOCK_REALTIME, &now) != 0) {
+            return -errno;
+        }
+        *timestamp = ConvertTimestampFromUnixToPG(now);
+        return 0;
+    }
+
+    if (tv[index].tv_nsec == UTIME_OMIT) {
+        if (oldStat == nullptr) {
+            return -EINVAL;
+        }
+        *timestamp = ConvertTimestampFromUnixToPG(index == 0 ? oldStat->st_atim : oldStat->st_mtim);
+        return 0;
+    }
+
+    *timestamp = ConvertTimestampFromUnixToPG(tv[index]);
+    return 0;
+}
 
 int DoGetAttr(const char *path, struct stat *stbuf)
 {
@@ -331,12 +370,35 @@ int DoUtimens(const char *path, const struct timespec tv[2])
     if (path == nullptr || strlen(path) == 0) {
         return -EINVAL;
     }
-    int ret = 0;
-    if (!tv || tv[0].tv_nsec == UTIME_NOW) {
-        ret = FalconUtimens(path);
-    } else {
-        ret = FalconUtimens(path, tv[0].tv_sec, tv[1].tv_sec);
+
+    if (!tv) {
+        int ret = FalconUtimens(path);
+        return ret > 0 ? -ErrorCodeToErrno(ret) : ret;
     }
+
+    if (tv[0].tv_nsec == UTIME_OMIT && tv[1].tv_nsec == UTIME_OMIT) {
+        return 0;
+    }
+
+    struct stat oldStat = {};
+    if (tv[0].tv_nsec == UTIME_OMIT || tv[1].tv_nsec == UTIME_OMIT) {
+        int ret = FalconGetStat(path, &oldStat);
+        if (ret != SUCCESS) {
+            return ret > 0 ? -ErrorCodeToErrno(ret) : ret;
+        }
+    }
+
+    int64_t accessTime = 0;
+    int64_t modifyTime = 0;
+    int ret = ResolveUtimensTimestamp(tv, 0, &oldStat, &accessTime);
+    if (ret != 0) {
+        return ret;
+    }
+    ret = ResolveUtimensTimestamp(tv, 1, &oldStat, &modifyTime);
+    if (ret != 0) {
+        return ret;
+    }
+    ret = FalconUtimens(path, accessTime, modifyTime);
     return ret > 0 ? -ErrorCodeToErrno(ret) : ret;
 }
 

--- a/falcon_client/src/connection.cpp
+++ b/falcon_client/src/connection.cpp
@@ -169,7 +169,7 @@ static timespec ConvertTimestampFromPGToUnix(uint64_t t)
     const static uint64_t SECONDS_DIFF_BETWEEN_PG_AND_UNIX = 946684800;
     timespec res;
     res.tv_sec = t / 1000000 + SECONDS_DIFF_BETWEEN_PG_AND_UNIX;
-    res.tv_nsec = t % 1000000;
+    res.tv_nsec = (t % 1000000) * 1000;
     return res;
 }
 

--- a/tests/falcon_meta_service_plugin/falcon_meta_service_test_plugin.cpp
+++ b/tests/falcon_meta_service_plugin/falcon_meta_service_test_plugin.cpp
@@ -34,6 +34,13 @@ static int g_test_skipped = 0;
 static bool g_is_cn_node = false;
 static std::atomic<int> g_loop_iteration(0);  // 循环计数器，用于生成唯一标识
 
+static uint64_t ConvertUnixSecondsToPgTimestamp(uint64_t unix_seconds)
+{
+    const uint64_t seconds_diff_between_pg_and_unix = 946684800;
+    const uint64_t usecs_per_sec = 1000000;
+    return (unix_seconds - seconds_diff_between_pg_and_unix) * usecs_per_sec;
+}
+
 struct SyncContext
 {
     std::mutex mtx;
@@ -871,12 +878,21 @@ static bool TestAttributeOperations()
     TEST_ASSERT(status == 0, "CREATE failed");
     printf("  Created test file: %s\n", file_path.c_str());
 
-    // 2. UTIMENS - 修改时间
-    uint64_t new_atime = 1609459200000000000ULL; // 2021-01-01 00:00:00 UTC in nanoseconds
-    uint64_t new_mtime = 1640995200000000000ULL; // 2022-01-01 00:00:00 UTC in nanoseconds
+    // 2. UTIMENS - 修改时间。元数据层使用 PostgreSQL TimestampTz: 自 2000-01-01 起的微秒。
+    uint64_t new_atime = ConvertUnixSecondsToPgTimestamp(1779073800ULL); // 2026-05-18 11:10:00 CST
+    uint64_t new_mtime = ConvertUnixSecondsToPgTimestamp(1779073860ULL); // 2026-05-18 11:11:00 CST
     status = DoUtimens(file_path, new_atime, new_mtime);
     TEST_ASSERT(status == 0, "UTIMENS failed");
     printf("  UTIMENS succeeded\n");
+
+    StatResponse stat_resp;
+    status = DoStat(file_path, &stat_resp);
+    TEST_ASSERT(status == 0, "STAT after UTIMENS failed");
+    TEST_ASSERT_MSG(
+        stat_resp.st_atim == new_atime, "UTIMENS atime mismatch: expected %lu, got %lu", new_atime, stat_resp.st_atim);
+    TEST_ASSERT_MSG(
+        stat_resp.st_mtim == new_mtime, "UTIMENS mtime mismatch: expected %lu, got %lu", new_mtime, stat_resp.st_mtim);
+    printf("  UTIMENS timestamp verified: atime=%lu, mtime=%lu\n", stat_resp.st_atim, stat_resp.st_mtim);
 
     // 3. CHMOD - 修改权限
     uint64_t new_mode = 0755;


### PR DESCRIPTION
## 问题背景

  FUSE DoUtimens() 当前直接把 struct timespec.tv_sec 传给元数据服务：

  FalconUtimens(path, tv[0].tv_sec, tv[1].tv_sec);

  但元数据层使用 PostgreSQL TimestampTz 存储时间戳，其语义是“自 2000-01-01 起的微秒数”，不是 Unix 秒。

  因此执行 Linux 命令：

  touch -t 05181111 file2.txt

  时，客户端传入的 Unix 秒会被后端当成 PG 微秒偏移解释，导致文件时间被错误修改到 Jan 1 2000 附近。

  另外，客户端从 PG 时间戳转换回 Unix timespec 时，tv_nsec 使用了微秒余数但没有乘以 1000，纳秒字段也存在换算错误。

  ## 修改方案

  1. 在 FUSE DoUtimens() 中增加 Unix timespec 到 PostgreSQL TimestampTz 的转换：
      - Unix epoch: 1970-01-01
      - PostgreSQL epoch: 2000-01-01
      - 后端时间单位: microseconds
  2. 补齐 utimens 特殊语义处理：
      - tv == nullptr：保持原逻辑，使用当前时间
      - UTIME_NOW：取当前 CLOCK_REALTIME
      - UTIME_OMIT：读取旧 stat，保持对应 atime/mtime 不变
      - 两个字段都是 UTIME_OMIT：直接返回成功
  3. 修正 PG 时间戳转 Unix timespec 时的纳秒换算：

  // before
  res.tv_nsec = t % 1000000;

  // after
  res.tv_nsec = (t % 1000000) * 1000;

  ## 验证

<img width="639" height="261" alt="image" src="https://github.com/user-attachments/assets/aa305605-7f5f-402f-9d19-87290eace176" />
