### PR TITLE
Add source dependency installation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,91 @@ We do not enable metadata replication. To saturate the metadata server's computi
 
 ## Build
 
-suppose at the `~/code` dir
+FalconFS can be built on an Ubuntu 24.04 host, an openEuler 24.03 host, or in the provided dev container.
+
+### Ubuntu 24.04 host
+
+Use `deb/install-third-party-ubuntu24.04.sh` to prepare dependencies. The script installs required apt packages, PostgreSQL 17, brpc, and prometheus-cpp. The `third_party` submodule is not required for this flow. OBS SDK is only needed when building with `--with-obs-storage`.
+
+Suppose at the `~/code` dir:
+
+``` bash
+git clone https://github.com/falcon-infra/falconfs.git
+cd falconfs
+bash deb/install-third-party-ubuntu24.04.sh
+./build.sh clean falcon
+./build.sh build falcon
+sudo -E ./build.sh install falcon
+source deploy/falcon_env.sh
+./deploy/falcon_start.sh
+./deploy/falcon_stop.sh
+```
+
+If you prefer installing apt dependencies manually, install the following packages first. PostgreSQL 17, brpc, and prometheus-cpp are still required; `deb/install-third-party-ubuntu24.04.sh` builds and installs them automatically.
+
+``` bash
+sudo apt-get update
+sudo apt-get install -y \
+  ca-certificates tzdata locales sudo git rsync tar wget curl \
+  make cmake ninja-build build-essential gcc-14 g++-14 \
+  bison flex m4 autoconf automake pkg-config libtool \
+  libreadline-dev liblz4-dev libzstd-dev zstd libssl-dev \
+  fuse libfuse-dev libflatbuffers-dev flatbuffers-compiler \
+  libprotoc-dev libprotobuf-dev protobuf-compiler \
+  libgflags-dev libjsoncpp-dev libleveldb-dev libsnappy-dev \
+  libfmt-dev libboost-thread-dev libboost-system-dev \
+  libboost-filesystem-dev libboost-program-options-dev \
+  libgtest-dev libgmock-dev libgoogle-glog-dev \
+  libzookeeper-mt-dev libibverbs-dev rdma-core \
+  libcurl4-openssl-dev libunwind-dev libjansson-dev \
+  libffi-dev libxml2-dev libsystemd-dev libthrift-dev \
+  libcppunit-dev python3 python3-dev python3-pip \
+  python3-requests python3-psycopg2 python3-kazoo \
+  jq moreutils iputils-ping net-tools
+```
+
+### openEuler 24.03 host
+
+Use `rpm/install-third-party-openEuler24.03.sh` to prepare dependencies. The script installs required dnf packages and builds PostgreSQL 17, brpc, prometheus-cpp, and ZooKeeper C client from source. OBS SDK is not installed by default.
+
+Suppose at the `~/code` dir:
+
+``` bash
+git clone https://github.com/falcon-infra/falconfs.git
+cd falconfs
+bash rpm/install-third-party-openEuler24.03.sh
+./build.sh clean falcon
+./build.sh build falcon --no-tests
+sudo -E ./build.sh install falcon --no-tests
+source deploy/falcon_env.sh
+./deploy/falcon_start.sh
+./deploy/falcon_stop.sh
+```
+
+If you prefer installing dependencies manually, the following `dnf` packages only cover system build dependencies. You must also build and install PostgreSQL 17, brpc, prometheus-cpp, and ZooKeeper C client from source; `rpm/install-third-party-openEuler24.03.sh` does that automatically.
+
+``` bash
+sudo dnf makecache
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf reinstall -y glibc-common
+sudo dnf install -y \
+  bash sudo git findutils shadow util-linux \
+  glibc-langpack-en glibc-all-langpacks \
+  gcc gcc-c++ make cmake ninja-build autoconf automake libtool \
+  bison flex readline-devel openssl-devel gflags-devel glog-devel \
+  leveldb-devel snappy-devel fmt-devel gperftools-devel \
+  libunwind-devel rdma-core-devel fuse-devel libcurl-devel \
+  jansson-devel libffi-devel libzstd-devel xz-devel expat-devel \
+  libxml2-devel systemd-devel protobuf-devel protobuf-compiler \
+  flatbuffers-devel flatbuffers-compiler jsoncpp-devel thrift-devel \
+  cppunit-devel gtest-devel gmock-devel python3 python3-devel \
+  python3-requests python3-psycopg2 python3-kazoo wget tar rsync \
+  libstdc++-static zstd-devel perl java-11-openjdk-devel maven \
+  hostname jq
+```
+
+### Provided dev container
+
 ``` bash
 git clone https://github.com/falcon-infra/falconfs.git
 cd falconfs

--- a/deb/README.source.md
+++ b/deb/README.source.md
@@ -7,9 +7,56 @@
 - `falconfs`（完整包）
 - `falconfs-release`（精简运行时包）
 
-## 1. 前置环境
+## 1. 空白 Ubuntu 24.04 机器准备
 
-### 1.1 第三方依赖（独立预装）
+在空白 Ubuntu 24.04 机器上，先安装最小拉代码工具：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y git ca-certificates sudo
+```
+
+拉取代码：
+
+```bash
+git clone <falconfs-repo-url> falconfs
+cd falconfs
+```
+
+安装 FalconFS 编译、打包和本地部署所需依赖：
+
+```bash
+bash deb/install-third-party-ubuntu24.04.sh
+```
+
+脚本默认准备：
+
+- Ubuntu apt 构建依赖，按 `debian/control` 和 `rpm/falconfs.source.spec` 对齐
+- PostgreSQL 17（默认 `/usr/local/pgsql`，提供 `pg_config`）
+- brpc（源码安装到 `/usr/local`）
+- prometheus-cpp（源码安装到 `/usr/local`）
+- ZooKeeper C client（使用 Ubuntu 包 `libzookeeper-mt-dev`，不源码编译）
+
+脚本会把 `pg_config` 软链到 `/usr/local/bin`，运行结束后当前 shell 可直接编译；其他 PostgreSQL 命令由 `deploy/falcon_env.sh` 通过 `pg_config --bindir` 加入 `PATH`。脚本也会写入 `/etc/profile.d/falconfs-third-party.sh` 供新 shell 自动加载环境。
+
+默认构建路径已解耦 OBS；仅在显式启用 `--with-obs-storage` 时才需要 OBS SDK。
+
+## 2. 源码编译与本地部署验证
+
+```bash
+./build.sh clean falcon
+./build.sh build falcon
+sudo -E ./build.sh install falcon
+source deploy/falcon_env.sh
+./deploy/falcon_start.sh
+./deploy/falcon_stop.sh
+```
+
+说明：本地启动脚本会使用默认 `brpc` 通信插件；若要验证 `hcom` 插件，需要先执行 `./build.sh build falcon --comm-plugin=hcom` 并按对应插件安装。
+
+## 3. Debian 打包
+
+### 3.1 第三方依赖（独立预装）
 
 先执行：
 
@@ -22,17 +69,15 @@ bash deb/install-third-party-ubuntu24.04.sh
 - PostgreSQL 17（`/usr/local/pgsql`）
 - brpc（源码安装）
 - prometheus-cpp（源码安装）
+- ZooKeeper C client（Ubuntu 包）
 
-默认构建路径已解耦 OBS；仅在显式启用 `--with-obs-storage` 时才需要 OBS SDK。
-
-### 1.2 Debian 打包工具
+构建 Debian 包还需要额外安装打包工具：
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y dpkg-dev debhelper devscripts fakeroot
+sudo apt-get install -y dpkg-dev debhelper devscripts fakeroot chrpath
 ```
 
-## 2. 构建 deb 包
+### 3.2 构建 deb 包
 
 在仓库根目录执行：
 
@@ -45,9 +90,9 @@ dpkg-buildpackage -b -us -uc
 - `../falconfs_0.1.0-1_*.deb`
 - `../falconfs-release_0.1.0-1_*.deb`
 
-## 3. 安装与验证
+## 4. 安装与验证
 
-### 3.1 安装
+### 4.1 安装
 
 ```bash
 sudo apt-get install -y ../falconfs_0.1.0-1_*.deb
@@ -55,7 +100,7 @@ sudo apt-get install -y ../falconfs_0.1.0-1_*.deb
 # sudo apt-get install -y ../falconfs-release_0.1.0-1_*.deb
 ```
 
-### 3.2 环境变量
+### 4.2 环境变量
 
 安装后会生成：`/etc/profile.d/falconfs.sh`
 
@@ -70,14 +115,14 @@ FalconFS 运行时动态库路径由启动脚本按进程设置，不在 profile
 source /etc/profile.d/falconfs.sh
 ```
 
-### 3.3 本地冒烟（完整包）
+### 4.3 本地冒烟（完整包）
 
 ```bash
 /usr/local/falconfs/deploy/falcon_start.sh
 /usr/local/falconfs/deploy/falcon_stop.sh
 ```
 
-### 3.4 可选日志目录配置
+### 4.4 可选日志目录配置
 
 默认情况下日志路径保持历史行为：
 
@@ -97,7 +142,7 @@ export FALCON_CN_DN_START_LOG_DIR=/path/to/cn-dn-start-logs
 
 - 不设置上述变量时，仍使用默认路径。
 
-## 4. 包内容说明
+## 5. 包内容说明
 
 - `falconfs`：完整安装目录 `/usr/local/falconfs`
 - `falconfs-release`：仅保留
@@ -108,9 +153,29 @@ export FALCON_CN_DN_START_LOG_DIR=/path/to/cn-dn-start-logs
 
 两个包互斥安装，不建议同时安装。
 
-## 5. Release 容器编排验证（docker-compose）
+## 6. 空白容器验证参考
 
-### 5.1 构建 Ubuntu release 运行时镜像
+本机已有 `ubuntu:24.04` 镜像时，可用一次性容器模拟空白机器。该验证会在容器内重新 clone 当前工作区内容并运行安装脚本：
+
+```bash
+docker run --rm --privileged -v "$PWD":/src:ro ubuntu:24.04 bash -lc '
+  apt-get update
+  apt-get install -y git ca-certificates sudo
+  git clone /src /work/falconfs
+  cd /work/falconfs
+  bash deb/install-third-party-ubuntu24.04.sh
+  ./build.sh clean falcon
+  ./build.sh build falcon
+  sudo -E ./build.sh install falcon
+  source deploy/falcon_env.sh
+  ./deploy/falcon_start.sh
+  ./deploy/falcon_stop.sh
+'
+```
+
+## 7. Release 容器编排验证（docker-compose）
+
+### 7.1 构建 Ubuntu release 运行时镜像
 
 将生成的 release deb 放到仓库根目录并重命名：
 
@@ -127,7 +192,7 @@ docker build \
   .
 ```
 
-### 5.2 用 compose 拉起 release 集群
+### 7.2 用 compose 拉起 release 集群
 
 ```bash
 export FALCON_RELEASE_IMAGE=falconfs-release-ubuntu24.04:v0.1.0

--- a/deb/install-third-party-ubuntu24.04.sh
+++ b/deb/install-third-party-ubuntu24.04.sh
@@ -206,11 +206,34 @@ verify_installation() {
     export PATH="${PG_PREFIX}/bin:/usr/local/bin:${PATH}"
     export LD_LIBRARY_PATH="${PG_PREFIX}/lib:/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH:-}"
 
-    pg_config --version
-    gcc --version | head -n 1
-    g++ --version | head -n 1
+    if ! command -v pg_config >/dev/null 2>&1; then
+        echo "Error: pg_config not found" >&2
+        exit 1
+    fi
 
-    ldconfig -p | grep -E 'libbrpc|libprometheus-cpp|libzookeeper_mt' || true
+    pg_version="$(pg_config --version)"
+    if [[ "$pg_version" != *"$PG_VERSION"* ]]; then
+        echo "Error: unexpected PostgreSQL version: $pg_version (expected $PG_VERSION)" >&2
+        exit 1
+    fi
+
+    if ! ldconfig -p | grep -q 'libbrpc\.so'; then
+        echo "Error: libbrpc not found in ldconfig cache" >&2
+        exit 1
+    fi
+
+    if ! ldconfig -p | grep -q 'libprometheus-cpp-core\.so'; then
+        echo "Error: libprometheus-cpp-core not found in ldconfig cache" >&2
+        exit 1
+    fi
+
+    if ! ldconfig -p | grep -q 'libzookeeper_mt\.so'; then
+        echo "Error: libzookeeper_mt not found in ldconfig cache" >&2
+        exit 1
+    fi
+
+    echo "Verified PostgreSQL: $pg_version"
+    echo "Verified brpc, prometheus-cpp, and ZooKeeper C client libraries."
 }
 
 main() {

--- a/rpm/README.source.md
+++ b/rpm/README.source.md
@@ -23,6 +23,14 @@ sudo dnf install -y rpmdevtools dnf-plugins-core
 sudo dnf builddep -y rpm/falconfs.source.spec
 ```
 
+在 openEuler 24.03 上，也可以直接运行源码依赖安装脚本。该脚本会安装系统构建依赖，并从源码安装 PostgreSQL 17、brpc、prometheus-cpp 和 ZooKeeper C client：
+
+```bash
+bash rpm/install-third-party-openEuler24.03.sh
+```
+
+说明：OBS SDK 不会默认安装；仅在显式启用 `--with-obs-storage` 时才需要单独准备。
+
 ### 1.3 外部预编译依赖（必须）
 
 本 spec 不负责编译这些第三方组件，需提前在构建机准备好：

--- a/rpm/install-third-party-openEuler24.03.sh
+++ b/rpm/install-third-party-openEuler24.03.sh
@@ -229,11 +229,34 @@ verify_installation() {
     export PATH="${PG_PREFIX}/bin:${INSTALL_PREFIX}/bin:${PATH}"
     export LD_LIBRARY_PATH="${PG_PREFIX}/lib:${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:${LD_LIBRARY_PATH:-}"
 
-    pg_config --version
-    gcc --version | head -n 1
-    g++ --version | head -n 1
+    if ! command -v pg_config >/dev/null 2>&1; then
+        echo "Error: pg_config not found" >&2
+        exit 1
+    fi
 
-    ldconfig -p | grep -E 'libbrpc|libprometheus-cpp|libzookeeper_mt' || true
+    pg_version="$(pg_config --version)"
+    if [[ "$pg_version" != *"$PG_VERSION"* ]]; then
+        echo "Error: unexpected PostgreSQL version: $pg_version (expected $PG_VERSION)" >&2
+        exit 1
+    fi
+
+    if ! ldconfig -p | grep -q 'libbrpc\.so'; then
+        echo "Error: libbrpc not found in ldconfig cache" >&2
+        exit 1
+    fi
+
+    if ! ldconfig -p | grep -q 'libprometheus-cpp-core\.so'; then
+        echo "Error: libprometheus-cpp-core not found in ldconfig cache" >&2
+        exit 1
+    fi
+
+    if ! ldconfig -p | grep -q 'libzookeeper_mt\.so'; then
+        echo "Error: libzookeeper_mt not found in ldconfig cache" >&2
+        exit 1
+    fi
+
+    echo "Verified PostgreSQL: $pg_version"
+    echo "Verified brpc, prometheus-cpp, and ZooKeeper C client libraries."
 }
 
 main() {

--- a/rpm/install-third-party-openEuler24.03.sh
+++ b/rpm/install-third-party-openEuler24.03.sh
@@ -2,13 +2,13 @@
 
 set -euo pipefail
 
-export DEBIAN_FRONTEND=noninteractive
-
 PG_VERSION="${PG_VERSION:-17.7}"
 BRPC_VERSION="${BRPC_VERSION:-1.14.1}"
-PROMETHEUS_CPP_VERSION="${PROMETHEUS_CPP_VERSION:-1.3.0}"
+PROMETHEUS_VERSION="${PROMETHEUS_VERSION:-1.3.0}"
+ZK_VERSION="${ZK_VERSION:-3.9.1}"
 
 PG_PREFIX="${PG_PREFIX:-/usr/local/pgsql}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 SOURCE_DIR="${SOURCE_DIR:-/tmp/falconfs-third-party-src}"
 
 if [[ "${EUID}" -eq 0 ]]; then
@@ -21,12 +21,21 @@ else
     SUDO="sudo"
 fi
 
+if command -v dnf >/dev/null 2>&1; then
+    PKG_MANAGER="dnf"
+elif command -v yum >/dev/null 2>&1; then
+    PKG_MANAGER="yum"
+else
+    echo "Error: dnf or yum is required on openEuler." >&2
+    exit 1
+fi
+
 retry_download() {
     local url="$1"
     local output="$2"
 
     for attempt in 1 2 3; do
-        if wget --timeout=120 --tries=1 -O "$output" "$url"; then
+        if wget --no-check-certificate --timeout=120 --tries=1 -O "$output" "$url"; then
             return 0
         fi
         echo "Download failed (attempt ${attempt}/3): ${url}" >&2
@@ -37,87 +46,73 @@ retry_download() {
     return 1
 }
 
-install_apt_dependencies() {
-    ${SUDO} apt-get update
-    ${SUDO} apt-get install -y \
-        ca-certificates \
-        tzdata \
-        locales \
+install_system_dependencies() {
+    ${SUDO} "$PKG_MANAGER" clean all || true
+    ${SUDO} "$PKG_MANAGER" makecache
+    ${SUDO} "$PKG_MANAGER" groupinstall -y "Development Tools" || true
+    ${SUDO} "$PKG_MANAGER" reinstall -y glibc-common || true
+    ${SUDO} "$PKG_MANAGER" install -y \
+        bash \
         sudo \
         git \
-        rsync \
-        tar \
-        wget \
-        curl \
+        findutils \
+        shadow \
+        util-linux \
+        glibc-langpack-en \
+        glibc-all-langpacks \
+        gcc \
+        gcc-c++ \
         make \
         cmake \
         ninja-build \
-        build-essential \
-        gcc-14 \
-        g++-14 \
-        bison \
-        flex \
-        m4 \
         autoconf \
         automake \
-        pkg-config \
         libtool \
-        libreadline-dev \
-        liblz4-dev \
-        libzstd-dev \
-        zstd \
-        libssl-dev \
-        fuse \
-        libfuse-dev \
-        libflatbuffers-dev \
-        flatbuffers-compiler \
-        libprotoc-dev \
-        libprotobuf-dev \
+        bison \
+        flex \
+        readline-devel \
+        openssl-devel \
+        gflags-devel \
+        glog-devel \
+        leveldb-devel \
+        snappy-devel \
+        fmt-devel \
+        gperftools-devel \
+        libunwind-devel \
+        rdma-core-devel \
+        fuse-devel \
+        libcurl-devel \
+        jansson-devel \
+        libffi-devel \
+        libzstd-devel \
+        xz-devel \
+        expat-devel \
+        libxml2-devel \
+        systemd-devel \
+        protobuf-devel \
         protobuf-compiler \
-        libgflags-dev \
-        libjsoncpp-dev \
-        libleveldb-dev \
-        libsnappy-dev \
-        libfmt-dev \
-        libboost-thread-dev \
-        libboost-system-dev \
-        libboost-filesystem-dev \
-        libboost-program-options-dev \
-        libgtest-dev \
-        libgmock-dev \
-        libgoogle-glog-dev \
-        libzookeeper-mt-dev \
-        libibverbs-dev \
-        rdma-core \
-        libcurl4-openssl-dev \
-        libunwind-dev \
-        libjansson-dev \
-        libffi-dev \
-        libxml2-dev \
-        libsystemd-dev \
-        libthrift-dev \
-        libcppunit-dev \
+        flatbuffers-devel \
+        flatbuffers-compiler \
+        jsoncpp-devel \
+        thrift-devel \
+        cppunit-devel \
+        gtest-devel \
+        gmock-devel \
         python3 \
-        python3-dev \
-        python3-pip \
+        python3-devel \
         python3-requests \
         python3-psycopg2 \
         python3-kazoo \
-        jq \
-        moreutils \
-        iputils-ping \
-        net-tools
-
-    ${SUDO} update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 60
-    ${SUDO} update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 60
-    ${SUDO} update-alternatives --set gcc /usr/bin/gcc-14
-    ${SUDO} update-alternatives --set g++ /usr/bin/g++-14
-
-    if [[ ! -e /usr/include/json && -d /usr/include/jsoncpp/json ]]; then
-        ${SUDO} ln -s /usr/include/jsoncpp/json /usr/include/json
-    fi
-
-    ${SUDO} locale-gen en_US.UTF-8
+        wget \
+        tar \
+        rsync \
+        libstdc++-static \
+        zstd-devel \
+        perl \
+        java-11-openjdk-devel \
+        maven \
+        hostname \
+        jq
 }
 
 install_postgresql() {
@@ -158,6 +153,9 @@ install_brpc() {
     cmake -S "$src_dir" -B "$src_dir/build" -GNinja \
         -DWITH_GLOG=ON \
         -DWITH_RDMA=ON \
+        -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+        -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX" \
+        -DCMAKE_CXX_FLAGS="-Wno-error -Wno-deprecated-declarations" \
         -DCMAKE_BUILD_TYPE=Release
     ninja -C "$src_dir/build"
     ${SUDO} ninja -C "$src_dir/build" install
@@ -169,9 +167,9 @@ install_prometheus_cpp() {
         return 0
     fi
 
-    local archive="${SOURCE_DIR}/prometheus-cpp-with-submodules-${PROMETHEUS_CPP_VERSION}.tar.gz"
+    local archive="${SOURCE_DIR}/prometheus-cpp-with-submodules-${PROMETHEUS_VERSION}.tar.gz"
     local src_dir="${SOURCE_DIR}/prometheus-cpp-with-submodules"
-    local url="https://github.com/jupp0r/prometheus-cpp/releases/download/v${PROMETHEUS_CPP_VERSION}/prometheus-cpp-with-submodules.tar.gz"
+    local url="https://github.com/jupp0r/prometheus-cpp/releases/download/v${PROMETHEUS_VERSION}/prometheus-cpp-with-submodules.tar.gz"
 
     rm -rf "$src_dir"
     retry_download "$url" "$archive"
@@ -181,15 +179,40 @@ install_prometheus_cpp() {
         -DBUILD_SHARED_LIBS=ON \
         -DENABLE_PULL=ON \
         -DENABLE_COMPRESSION=OFF \
+        -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
         -DCMAKE_BUILD_TYPE=Release
     make -C "$src_dir/build" -j"$(nproc)"
     ${SUDO} make -C "$src_dir/build" install
 }
 
+install_zookeeper_c_client() {
+    if ldconfig -p 2>/dev/null | grep -q 'libzookeeper_mt\.so'; then
+        echo "ZooKeeper C client already installed."
+        return 0
+    fi
+
+    local archive="${SOURCE_DIR}/apache-zookeeper-${ZK_VERSION}.tar.gz"
+    local src_dir="${SOURCE_DIR}/apache-zookeeper-${ZK_VERSION}"
+    local url="https://archive.apache.org/dist/zookeeper/zookeeper-${ZK_VERSION}/apache-zookeeper-${ZK_VERSION}.tar.gz"
+
+    rm -rf "$src_dir"
+    retry_download "$url" "$archive"
+    tar -xzf "$archive" -C "$SOURCE_DIR"
+
+    pushd "$src_dir" >/dev/null
+    mvn compile -DskipTests -pl zookeeper-jute -T 1C
+    cd zookeeper-client/zookeeper-client-c
+    autoreconf -if
+    ./configure --prefix="$INSTALL_PREFIX"
+    make -j"$(nproc)"
+    ${SUDO} make install
+    popd >/dev/null
+}
+
 configure_environment() {
     ${SUDO} tee /etc/ld.so.conf.d/falconfs-third-party.conf >/dev/null <<EOF
-/usr/local/lib
-/usr/local/lib64
+${INSTALL_PREFIX}/lib
+${INSTALL_PREFIX}/lib64
 ${PG_PREFIX}/lib
 EOF
     ${SUDO} ldconfig
@@ -197,14 +220,14 @@ EOF
     ${SUDO} ln -sf "${PG_PREFIX}/bin/pg_config" /usr/local/bin/pg_config
 
     ${SUDO} tee /etc/profile.d/falconfs-third-party.sh >/dev/null <<EOF
-export PATH=${PG_PREFIX}/bin:/usr/local/bin:\$PATH
-export LD_LIBRARY_PATH=${PG_PREFIX}/lib:/usr/local/lib:/usr/local/lib64:\${LD_LIBRARY_PATH:-}
+export PATH=${PG_PREFIX}/bin:${INSTALL_PREFIX}/bin:\$PATH
+export LD_LIBRARY_PATH=${PG_PREFIX}/lib:${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:\${LD_LIBRARY_PATH:-}
 EOF
 }
 
 verify_installation() {
-    export PATH="${PG_PREFIX}/bin:/usr/local/bin:${PATH}"
-    export LD_LIBRARY_PATH="${PG_PREFIX}/lib:/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH:-}"
+    export PATH="${PG_PREFIX}/bin:${INSTALL_PREFIX}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${PG_PREFIX}/lib:${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:${LD_LIBRARY_PATH:-}"
 
     pg_config --version
     gcc --version | head -n 1
@@ -215,16 +238,16 @@ verify_installation() {
 
 main() {
     mkdir -p "$SOURCE_DIR"
-    install_apt_dependencies
+    install_system_dependencies
     install_postgresql
     install_brpc
     install_prometheus_cpp
+    install_zookeeper_c_client
     configure_environment
     verify_installation
 
-    echo "Third-party dependencies installed."
-    echo "pg_config is linked into /usr/local/bin for immediate build use."
-    echo "OBS SDK is optional; install it only when building with --with-obs-storage."
+    echo "Third-party dependencies installed for openEuler 24.03."
+    echo "OBS SDK is not installed; install it separately only when building with --with-obs-storage."
 }
 
 main "$@"


### PR DESCRIPTION
Add third-party dependency installation scripts and documentation for Ubuntu 24.04 and openEuler 24.03, enabling FalconFS to be built and deployed from source on a clean environment.

Update README build instructions with host-based setup flows and manual dependency lists.

Expand Debian packaging documentation with the clean-machine validation workflow.

Add an openEuler 24.03 source installation script that builds and installs PostgreSQL, brpc, prometheus-cpp, and the ZooKeeper C client from source.