### PR TITLE
Fix/falcon graceful shutdown

### DIFF
--- a/falcon/brpc_comm_adapter/falcon_brpc_server.cpp
+++ b/falcon/brpc_comm_adapter/falcon_brpc_server.cpp
@@ -46,8 +46,8 @@ class FalconBrpcServer {
     }
     void Shutdown()
     {
+        brpc::AskToQuit();
         m_server.Stop(0);
-        m_server.Join();
     }
 
   private:
@@ -89,7 +89,6 @@ int StopFalconCommunicationServer()
     try {
         if (g_falconBrpcServerInstance != NULL) {
             g_falconBrpcServerInstance->Shutdown();
-            g_falconBrpcServerInstance = NULL;
             return 0;
         }
     } catch (const std::exception &e) {

--- a/falcon/connection_pool/falcon_connection_pool.c
+++ b/falcon/connection_pool/falcon_connection_pool.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <link.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <threads.h>
 #include <unistd.h>
@@ -52,8 +53,13 @@ static falcon_plugin_flush_coverage_func_t comm_flush_coverage_func = NULL;
 static void (*comm_plugin_gcov_dump_func)(void) = NULL;
 static void *falcon_comm_dl_handle = NULL;
 
-static volatile bool got_SIGTERM = false;
+static volatile sig_atomic_t got_SIGTERM = false;
+static thrd_t comm_server_thread;
+static bool comm_server_thread_started = false;
+static atomic_bool comm_server_done = false;
+static int comm_server_rc = 0;
 static void FalconDaemonConnectionPoolProcessSigTermHandler(SIGNAL_ARGS);
+static int CommunicationServerThreadMain(void *arg);
 
 static void *ResolveLocalSymbolAddress(void *handle, const char *symbolName)
 {
@@ -213,6 +219,9 @@ void FalconDaemonConnectionPoolProcessMain(unsigned long int main_arg)
     // PostPortNumber need using both here and falcon_run_pooler_server_func, so set to global variable FalconPGPort
     FalconPGPort = PostPortNumber;
     RunConnectionPoolServer();
+    if (got_SIGTERM) {
+        return;
+    }
     elog(LOG, "FalconDaemonConnectionPoolProcessMain: connection pool server stopped.");
     return;
 }
@@ -221,28 +230,7 @@ static void FalconDaemonConnectionPoolProcessSigTermHandler(SIGNAL_ARGS)
 {
     int save_errno = errno;
 
-    FlushCoverageData();
-    FlushCoverageDataForPlugin();
-
-    elog(LOG, "FalconDaemonConnectionPoolProcessSigTermHandler: get sigterm.");
     got_SIGTERM = true;
-
-    DestroyPGConnectionPool();
-    if (comm_cleanup_func != NULL) {
-        comm_cleanup_func();
-        comm_cleanup_func = NULL;
-    }
-
-    if (falcon_comm_dl_handle != NULL) {
-        FlushCoverageDataForPlugin();
-        dlclose(falcon_comm_dl_handle);
-        comm_work_func = NULL;
-        comm_flush_coverage_func = NULL;
-        comm_plugin_gcov_dump_func = NULL;
-        falcon_comm_dl_handle = NULL;
-    }
-
-    FlushCoverageData();
 
     errno = save_errno;
 }
@@ -299,19 +287,45 @@ static void StartCommunicationSever()
         return;
     }
 
-    /* Execute plugin work */
-    int ret =
-        comm_work_func(FalconDispatchMetaJob2PGConnectionPool, FalconCommunicationServerIp, FalconConnectionPoolPort);
-    if (ret != 0) {
-        elog(ERROR, "Plugin work function returned %d: %s", ret, FalconCommunicationPluginPath);
+    atomic_store(&comm_server_done, false);
+    comm_server_rc = 0;
+    if (thrd_create(&comm_server_thread, CommunicationServerThreadMain, NULL) != thrd_success) {
+        elog(ERROR, "Failed to create communication server thread: %s", FalconCommunicationPluginPath);
         dlclose(falcon_comm_dl_handle);
         return;
     }
-    /* Cleanup */
+    comm_server_thread_started = true;
+
+    while (!got_SIGTERM && !atomic_load(&comm_server_done)) {
+        sleep(1);
+    }
+
+    if (got_SIGTERM && !atomic_load(&comm_server_done) && comm_cleanup_func != NULL) {
+        comm_cleanup_func();
+    }
+    if (comm_server_thread_started) {
+        thrd_join(comm_server_thread, &comm_server_rc);
+        comm_server_thread_started = false;
+    }
+    if (!got_SIGTERM && comm_server_rc != 0) {
+        elog(ERROR, "Plugin work function returned %d: %s", comm_server_rc, FalconCommunicationPluginPath);
+        dlclose(falcon_comm_dl_handle);
+        return;
+    }
+
+    if (got_SIGTERM) {
+        comm_cleanup_func = NULL;
+        comm_work_func = NULL;
+        comm_flush_coverage_func = NULL;
+        comm_plugin_gcov_dump_func = NULL;
+        falcon_comm_dl_handle = NULL;
+        return;
+    }
+
     elog(LOG, "Background worker stopping: %s", FalconCommunicationPluginPath);
     FlushCoverageData();
+
     FlushCoverageDataForPlugin();
-    comm_cleanup_func();
     comm_cleanup_func = NULL;
 
     FlushCoverageDataForPlugin();
@@ -321,6 +335,15 @@ static void StartCommunicationSever()
     comm_plugin_gcov_dump_func = NULL;
     falcon_comm_dl_handle = NULL;
     FlushCoverageData();
+}
+
+static int CommunicationServerThreadMain(void *arg)
+{
+    (void)arg;
+    comm_server_rc =
+        comm_work_func(FalconDispatchMetaJob2PGConnectionPool, FalconCommunicationServerIp, FalconConnectionPoolPort);
+    atomic_store(&comm_server_done, true);
+    return comm_server_rc;
 }
 
 void RunConnectionPoolServer(void)
@@ -333,4 +356,5 @@ void RunConnectionPoolServer(void)
 
     // start Communication Server receive jobs and dispatch jobs to PGConnectionPool
     StartCommunicationSever();
+    DestroyPGConnectionPool();
 }

--- a/falcon/connection_pool/pg_connection.cpp
+++ b/falcon/connection_pool/pg_connection.cpp
@@ -11,7 +11,7 @@
 PGConnection::PGConnection(PGConnectionWorkFinishNotifyFunc func, const char *ip, const int port, const char *userName)
 {
     m_workerFinishNotifyFunc = func;
-    working = true;
+    working.store(true);
     std::stringstream ss;
     ss << "hostaddr=" << ip << " port=" << port << " user=" << userName << " dbname=postgres";
     conn = PQconnectdb(ss.str().c_str());
@@ -29,11 +29,15 @@ PGConnection::PGConnection(PGConnectionWorkFinishNotifyFunc func, const char *ip
 
 void PGConnection::BackgroundWorker()
 {
-    while (working) {
-        if (!working)
-            break;
+    while (working.load()) {
         std::shared_ptr<BaseWorkerTask> baseWorkerTaskPtr(nullptr);
-        m_workerTaskQueue.pull(baseWorkerTaskPtr);
+        boost::concurrent::queue_op_status status = m_workerTaskQueue.wait_pull(baseWorkerTaskPtr);
+        if (status == boost::concurrent::queue_op_status::closed || !working.load()) {
+            break;
+        }
+        if (baseWorkerTaskPtr == nullptr) {
+            continue;
+        }
         try {
             baseWorkerTaskPtr->DoWork(conn, flatBufferBuilder, replyBuilder);
         } catch (const std::exception &) {
@@ -51,15 +55,25 @@ void PGConnection::BackgroundWorker()
 
 void PGConnection::Exec(std::shared_ptr<BaseWorkerTask> workerTaskPtr)
 {
-    this->m_workerTaskQueue.push(workerTaskPtr);
+    if (!working.load()) {
+        return;
+    }
+    this->m_workerTaskQueue.wait_push(workerTaskPtr);
 }
 
-void PGConnection::Stop() { working = false; }
+void PGConnection::Stop()
+{
+    if (working.exchange(false)) {
+        m_workerTaskQueue.close();
+    }
+}
 
 PGConnection::~PGConnection()
 {
     Stop();
-    thread.join();
+    if (thread.joinable()) {
+        thread.join();
+    }
     if (conn) {
         PQfinish(conn);
         conn = nullptr;

--- a/falcon/hcom_comm_adapter/falcon_meta_service.cpp
+++ b/falcon/hcom_comm_adapter/falcon_meta_service.cpp
@@ -1043,7 +1043,6 @@ int StopFalconCommunicationServer()
     try {
         if (falcon::meta_service::g_falconHcomServerInstance != nullptr) {
             falcon::meta_service::g_falconHcomServerInstance->Shutdown();
-            falcon::meta_service::g_falconHcomServerInstance = nullptr;
             falcon::meta_service::g_dispatchFunc = nullptr;
             return 0;
         }

--- a/falcon/include/connection_pool/pg_connection.h
+++ b/falcon/include/connection_pool/pg_connection.h
@@ -6,6 +6,7 @@
 #define FALCON_POOLER_PG_CONNECTION_H
 
 #include <condition_variable>
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -22,7 +23,7 @@
 class PGConnection {
   private:
     typedef std::function<void(PGConnection *conn)> PGConnectionWorkFinishNotifyFunc;
-    bool working;
+    std::atomic<bool> working;
     PGConnectionWorkFinishNotifyFunc m_workerFinishNotifyFunc;
     flatbuffers::FlatBufferBuilder flatBufferBuilder;
     SerializedData replyBuilder;

--- a/falcon/transaction/transaction_cleanup.c
+++ b/falcon/transaction/transaction_cleanup.c
@@ -82,7 +82,7 @@ void FalconDaemon2PCFailureCleanupProcessMain(Datum main_arg)
     CurrentResourceOwner = myOwner;
     elog(LOG, "FalconDaemon2PCFailureCleanupProcessMain: wait init.");
     bool falconHasBeenLoad = false;
-    while (true)
+    while (!got_SIGTERM)
     {
         StartTransactionCommand();
         falconHasBeenLoad = CheckFalconHasBeenLoaded();
@@ -93,13 +93,16 @@ void FalconDaemon2PCFailureCleanupProcessMain(Datum main_arg)
         sleep(1);
     }
     bool serviceStarted = false;
-    do {
+    while (!got_SIGTERM) {
         sleep(1);
         serviceStarted = CheckFalconBackgroundServiceStarted();
-    } while (!serviceStarted || RecoveryInProgress());
+        if (serviceStarted && !RecoveryInProgress()) {
+            break;
+        }
+    }
     elog(LOG, "FalconDaemon2PCFailureCleanupProcessMain: init finished.");
     int serverId = -1;
-    while (true)
+    while (!got_SIGTERM)
     {
         StartTransactionCommand();
         serverId = GetLocalServerId();
@@ -110,7 +113,7 @@ void FalconDaemon2PCFailureCleanupProcessMain(Datum main_arg)
         // wait for shard table init
         sleep(1);
     }
-    if (serverId == 0) {
+    if (serverId == 0 && !got_SIGTERM) {
         elog(LOG, "FalconDaemon2PCFailureCleanupProcessMain: Running.");
         while (!got_SIGTERM) {
             MemoryContext oldContext = MemoryContextSwitchTo(myContext);
@@ -440,7 +443,6 @@ static void FalconDaemon2PCCleanupProcessSigTermHandler(SIGNAL_ARGS)
 {
     int save_errno = errno;
 
-    elog(LOG, "FalconDaemon2PCCleanupProcessSigTermHandler: get sigterm.");
     got_SIGTERM = true;
 
     errno = save_errno;


### PR DESCRIPTION
## Summary
This PR improves Falcon meta background worker shutdown behavior during PostgreSQL fast shutdown / `pg_ctl restart`.
Previously, `pg_ctl restart -m fast` could hang or cause abnormal shutdown because Falcon background workers and communication plugins did not always exit cleanly after receiving shutdown signals.
The fix covers the connection pool worker, communication plugins, PGConnection worker threads, and 2PC cleanup worker initialization loops.

## What Changed
### Connection pool worker shutdown
- Move communication plugin execution into a dedicated thread instead of running it directly in the connection pool worker main flow.
- Let the connection pool worker main thread monitor `SIGTERM` and communication thread completion.
- On shutdown, stop the communication plugin first, then join the communication thread, then destroy the PG connection pool.
- Avoid complex cleanup directly inside the SIGTERM handler.

This prevents the connection pool worker main thread from being blocked forever inside plugin-specific server loops.

### PostgreSQL interrupt-safe SIGTERM path
- Remove `elog(LOG, ...)` from the connection pool SIGTERM handler.
- Skip shutdown-path `elog(LOG, ...)` calls after `got_SIGTERM` is set.
- Avoid running coverage flush logic on the SIGTERM path.

PostgreSQL `elog(LOG)` eventually reaches `errfinish()`, which calls `CHECK_FOR_INTERRUPTS()`. During fast shutdown, pending interrupt flags can cause `ProcessInterrupts()` to raise:
ERROR: canceling statement due to user request
This previously interrupted Falcon cleanup and caused the background worker to exit with code 1.

### brpc communication plugin
- Add `brpc::AskToQuit()` before stopping the brpc server.
- Remove the blocking `m_server.Join()` from plugin shutdown and let the connection pool thread join the communication thread instead.

This allows `brpc::Server::RunUntilAskedToQuit()` to return during fast shutdown.

### hcom communication plugin
- Keep the hcom server instance alive after `Shutdown()` instead of immediately resetting the global unique_ptr.
- Avoid destroying FalconHcomServer while the communication thread may still be running inside `Run()`.

This prevents a potential use-after-free or double cleanup risk during shutdown.

### PGConnection worker shutdown
- Change `PGConnection::working` to `std::atomic<bool>`.
- Replace blocking queue pull with `wait_pull()`.
- Close the worker queue in `Stop()` to wake workers waiting on an empty queue.
- Guard thread joining with `joinable()`.

This prevents PGConnection worker threads from hanging during pool destruction.

### 2PC cleanup worker shutdown
- Make initialization wait loops check `got_SIGTERM`.
- Skip entering the cleanup main loop if shutdown was requested during initialization.
- Remove `elog(LOG, ...)` from the 2PC cleanup SIGTERM handler.

This prevents `falcon_2pc_cleanup_process` from blocking PostgreSQL shutdown while waiting for Falcon services to finish initialization.

## Root Cause
There were multiple shutdown issues triggered by PostgreSQL fast shutdown:

1. Communication plugins could block the connection pool worker main flow.
2. brpc RunUntilAskedToQuit() was not woken by Stop() alone.
3. PGConnection worker threads could remain blocked waiting on an empty queue.
4. Falcon called PostgreSQL elog(LOG) after SIGTERM, which could trigger pending PostgreSQL interrupts.
5. 2PC cleanup worker initialization loops did not observe shutdown requests.
6. hcom shutdown could destroy the server object while its communication thread was still using it.

Together, these could lead to:
- `pg_ctl: server does not shut down`
- `ERROR: canceling statement due to user request`
- `terminate called without an active exception`
- `background worker "falcon_daemon_connection_pool_process" was terminated by signal 6: Aborted`
- `abnormal database system shutdown`

## Verification
Verified brpc mode:
./build.sh build falcon --no-tests
sudo -E ./build.sh install falcon --no-tests
pg_ctl restart -D ~/metadata/coordinator0 -m fast -w -t 120
pg_ctl restart -D ~/metadata/coordinator0 -m fast -w -t 120
pg_ctl restart -D ~/metadata/worker0 -m fast -w -t 120
pg_ctl restart -D ~/metadata/worker0 -m fast -w -t 120
<img width="1397" height="588" alt="image" src="https://github.com/user-attachments/assets/38a248e1-80b8-4c5b-9f5c-2f27c331999d" />

